### PR TITLE
fix: support DB::raw() for force index

### DIFF
--- a/src/database/src/Connection.php
+++ b/src/database/src/Connection.php
@@ -231,7 +231,7 @@ class Connection implements ConnectionInterface
     /**
      * Begin a fluent query against a database table.
      */
-    public function table(string $table): Builder
+    public function table($table): Builder
     {
         return $this->query()->from($table);
     }


### PR DESCRIPTION
```php
        return Db::raw(sprintf('%s FORCE INDEX(%s)', $table, $input['force_index']));
```