### PR TITLE
Add support for array value of RequestMapping::$methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Added
 
 - [#245](https://github.com/hyperf-cloud/hyperf/pull/245) Added TaskWorkerStrategy and WorkerStrategy crontab strategies.
-- [#254](https://github.com/hyperf-cloud/hyperf/pull/254) Added support for array value of `RequestMapping::$methods`, `@RequestMapping(methods={"GET"})` and `@RequestMapping(methods={RequestMapping::GET})` is available now.
+- [#254](https://github.com/hyperf-cloud/hyperf/pull/254) Added support for array value of `RequestMapping::$methods`, `@RequestMapping(methods={"GET"})` and `@RequestMapping(methods={RequestMapping::GET})` are available now.
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 
 - [#245](https://github.com/hyperf-cloud/hyperf/pull/245) Added TaskWorkerStrategy and WorkerStrategy crontab strategies.
+- [#254](https://github.com/hyperf-cloud/hyperf/pull/254) Added support for array value of `RequestMapping::$methods`, `@RequestMapping(methods={"GET"})` and `@RequestMapping(methods={RequestMapping::GET})` is available now.
 
 ## Changed
 

--- a/src/di/src/Annotation/AbstractAnnotation.php
+++ b/src/di/src/Annotation/AbstractAnnotation.php
@@ -54,7 +54,7 @@ abstract class AbstractAnnotation implements AnnotationInterface, Arrayable
         AnnotationCollector::collectProperty($className, $target, static::class, $this);
     }
 
-    protected function bindMainProperty(string $key, array $value)
+    protected function bindMainProperty(string $key, ?array $value)
     {
         if (isset($value['value'])) {
             $this->{$key} = $value['value'];

--- a/src/http-server/src/Annotation/RequestMapping.php
+++ b/src/http-server/src/Annotation/RequestMapping.php
@@ -20,6 +20,21 @@ use Hyperf\Utils\Str;
  */
 class RequestMapping extends Mapping
 {
+
+    public const GET = 'GET';
+
+    public const POST = 'POST';
+
+    public const PUT = 'PUT';
+
+    public const PATCH = 'PATCH';
+
+    public const DELETE = 'DELETE';
+
+    public const HEADER = 'HEADER';
+
+    public const OPTIONS = 'OPTIONS';
+
     /**
      * @var array
      */
@@ -29,8 +44,12 @@ class RequestMapping extends Mapping
     {
         parent::__construct($value);
         if (isset($value['methods'])) {
-            // Explode a string to a array
-            $this->methods = explode(',', Str::upper(str_replace(' ', '', $value['methods'])));
+            if (is_string($value['methods'])) {
+                // Explode a string to a array
+                $this->methods = explode(',', Str::upper(str_replace(' ', '', $value['methods'])));
+            } else {
+                $this->methods = $value['methods'];
+            }
         }
     }
 }

--- a/src/http-server/src/Annotation/RequestMapping.php
+++ b/src/http-server/src/Annotation/RequestMapping.php
@@ -48,7 +48,11 @@ class RequestMapping extends Mapping
                 // Explode a string to a array
                 $this->methods = explode(',', Str::upper(str_replace(' ', '', $value['methods'])));
             } else {
-                $this->methods = $value['methods'];
+                $methods = [];
+                foreach ($value['methods'] as $method) {
+                    $methods[] = Str::upper(str_replace(' ', '', $method));
+                }
+                $this->methods = $methods;
             }
         }
     }

--- a/src/http-server/tests/MappingAnnotationTest.php
+++ b/src/http-server/tests/MappingAnnotationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace HyperfTest\HttpServer;
+
+
+use Hyperf\HttpServer\Annotation\RequestMapping;
+use PHPUnit\Framework\TestCase;
+
+class MappingAnnotationTest extends TestCase
+{
+
+    public function testRequestMapping()
+    {
+        $mapping = new RequestMapping([]);
+        // Assert default methods
+        $this->assertSame(['GET', 'POST'], $mapping->methods);
+        $this->assertNull($mapping->path);
+
+        // Normal case
+        $mapping = new RequestMapping([
+            'methods' => 'get,post,put',
+            'path' => $path = '/foo',
+        ]);
+        $this->assertSame(['GET', 'POST', 'PUT'], $mapping->methods);
+        $this->assertSame($path, $mapping->path);
+
+        // The methods have space
+        $mapping = new RequestMapping([
+            'methods' => 'get, post,  put',
+            'path' => $path,
+        ]);
+        $this->assertSame(['GET', 'POST', 'PUT'], $mapping->methods);
+        $this->assertSame($path, $mapping->path);
+    }
+
+    public function testRequestMappingWithArrayMethods()
+    {
+        $mapping = new RequestMapping([
+            'methods' => [
+                'GET', 'POST ', 'put'
+            ],
+            'path' => $path = '/foo',
+        ]);
+        $this->assertSame(['GET', 'POST', 'PUT'], $mapping->methods);
+        $this->assertSame($path, $mapping->path);
+    }
+
+    public function testRequestMappingBindMainProperty()
+    {
+        $mapping = new RequestMapping(['value' => '/foo']);
+        $this->assertSame(['GET', 'POST'], $mapping->methods);
+        $this->assertSame('/foo', $mapping->path);
+    }
+}


### PR DESCRIPTION
Add support for usage way below:
1. 
```php
/**
 * @RequestMapping(methods={"GET"})
 */
```
2. 
```php
/**
 * @RequestMapping(methods={RequestMapping::GET})
 */
```