### PR TITLE
Optimized json-rpc error handling, and Added IdGeneratorInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 - [#245](https://github.com/hyperf-cloud/hyperf/pull/245) Added TaskWorkerStrategy and WorkerStrategy crontab strategies.
 - [#254](https://github.com/hyperf-cloud/hyperf/pull/254) Added support for array value of `RequestMapping::$methods`, `@RequestMapping(methods={"GET"})` and `@RequestMapping(methods={RequestMapping::GET})` are available now.
 - [#255](https://github.com/hyperf-cloud/hyperf/pull/255) Transfer `Hyperf\Utils\Contracts\Arrayable` result of Request to Response automatically, and added `text/plain` content-type header for string Response.
+- [#256](https://github.com/hyperf-cloud/hyperf/pull/256) If `Hyperf\Contract\IdGeneratorInterface` exist, the `json-rpc` client will generate a Request ID via IdGenerator automatically, and stored in Request attibute. Also added support for service register and health checks of `jsonrpc` TCP protocol.
 
 ## Changed
 
 - [#247](https://github.com/hyperf-cloud/hyperf/pull/247) Use Use `WorkerStrategy` as the default crontab strategy.
+- [#256](https://github.com/hyperf-cloud/hyperf/pull/256) Optimized error handling of json-rpc, and will response a standard json-rpc error object when the rpc method does not exist.
 
 ## Fixed
 

--- a/src/contract/src/IdGeneratorInterface.php
+++ b/src/contract/src/IdGeneratorInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf-cloud/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Contract;
+
+interface IdGeneratorInterface
+{
+    public function generate(): string;
+}

--- a/src/http-message/src/Base/Request.php
+++ b/src/http-message/src/Base/Request.php
@@ -239,11 +239,11 @@ class Request implements RequestInterface
             $host .= ':' . $port;
         }
 
+        $header = 'host';
         if ($this->hasHeader('host')) {
-            $header = $this->getHeaderLine('host');
+            $host = $this->getHeaderLine('host');
         } else {
-            $header = 'Host';
-            $this->headerNames['host'] = 'Host';
+            $this->headerNames['host'] = 'host';
         }
         // Ensure Host is the first header.
         $this->headers = [$header => [$host]] + $this->headers;

--- a/src/json-rpc/src/DataFormatter.php
+++ b/src/json-rpc/src/DataFormatter.php
@@ -18,11 +18,12 @@ class DataFormatter implements DataFormatterInterface
 {
     public function formatRequest($data)
     {
-        [$path, $params] = $data;
+        [$path, $params, $id] = $data;
         return [
             'jsonrpc' => '2.0',
             'method' => $path,
             'params' => $params,
+            'id' => $id,
         ];
     }
 
@@ -35,4 +36,20 @@ class DataFormatter implements DataFormatterInterface
             'result' => $result,
         ];
     }
+
+    public function formatErrorResponse($data)
+    {
+        [$id, $code, $message, $data] = $data;
+        return [
+            'jsonrpc' => '2.0',
+            'id' => $id ?? null,
+            'error' => [
+                'code' => $code,
+                'message' => $message,
+                'data' => $data,
+            ],
+        ];
+    }
+
+
 }

--- a/src/json-rpc/src/HttpCoreMiddleware.php
+++ b/src/json-rpc/src/HttpCoreMiddleware.php
@@ -28,6 +28,10 @@ class HttpCoreMiddleware extends CoreMiddleware
         $protocolName = 'jsonrpc-http';
         $this->dataFormatter = $container->get($this->protocolManager->getDataFormatter($protocolName));
         $this->packer = $container->get($this->protocolManager->getPacker($protocolName));
+        $this->responseBuilder = make(ResponseBuilder::class, [
+            'dataFormatter' => $this->dataFormatter,
+            'packer' => $this->packer,
+        ]);
     }
 
     protected function handleNotFound(ServerRequestInterface $request)

--- a/src/json-rpc/src/ResponseBuilder.php
+++ b/src/json-rpc/src/ResponseBuilder.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf-cloud/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\JsonRpc;
+
+use Hyperf\Contract\PackerInterface;
+use Hyperf\HttpMessage\Stream\SwooleStream;
+use Hyperf\Rpc\Contract\DataFormatterInterface;
+use Hyperf\Utils\Context;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class ResponseBuilder
+{
+    /**
+     * @var \Hyperf\Rpc\Contract\DataFormatterInterface
+     */
+    protected $dataFormatter;
+
+    /**
+     * @var PackerInterface
+     */
+    protected $packer;
+
+    public function __construct(DataFormatterInterface $dataFormatter, PackerInterface $packer)
+    {
+        $this->dataFormatter = $dataFormatter;
+        $this->packer = $packer;
+    }
+
+    public function buildErrorResponse(ServerRequestInterface $request, int $code): ResponseInterface
+    {
+        $body = new SwooleStream($this->formatErrorResponse($request, $code));
+        return $this->response()->withAddedHeader('content-type', 'application/json')->withBody($body);
+    }
+
+    public function buildResponse(ServerRequestInterface $request, $response): ResponseInterface
+    {
+        $body = new SwooleStream($this->formatResponse($response, $request));
+        return $this->response()
+            ->withAddedHeader('content-type', 'application/json')
+            ->withBody($body);
+    }
+
+    protected function formatResponse($response, ServerRequestInterface $request): string
+    {
+        $response = $this->dataFormatter->formatResponse([$request->getAttribute('request_id') ?? '', $response]);
+        return $this->packer->pack($response);
+    }
+
+    protected function formatErrorResponse(ServerRequestInterface $request, int $code): string
+    {
+        [$code, $message] = $this->error($code);
+        $response = $this->dataFormatter->formatErrorResponse([$request->getAttribute('request_id') ?? '', $code, $message, null]);
+        return $this->packer->pack($response);
+    }
+
+    protected function error(int $code, ?string $message = null): array
+    {
+        $mapping = [
+            -32700 => 'Parse error.',
+            -32600 => 'Invalid request.',
+            -32601 => 'Method not found.',
+            -32602 => 'Invalid params.',
+            -32603 => 'Internal error.',
+        ];
+        if (isset($mapping[$code])) {
+            return [$code, $mapping[$code]];
+        }
+        return [$code, $message ?? ''];
+    }
+
+    /**
+     * Get response instance from context.
+     */
+    protected function response(): ResponseInterface
+    {
+        return Context::get(ResponseInterface::class);
+    }
+}

--- a/src/rpc-client/src/Client.php
+++ b/src/rpc-client/src/Client.php
@@ -39,7 +39,7 @@ class Client
         $packer = $this->getPacker();
         $packedData = $packer->pack($data);
         $response = $this->getTransporter()->send($packedData);
-        return $packer->unpack($response);
+        return $packer->unpack((string) $response);
     }
 
     public function getPacker(): PackerInterface

--- a/src/rpc-server/src/CoreMiddleware.php
+++ b/src/rpc-server/src/CoreMiddleware.php
@@ -32,11 +32,6 @@ class CoreMiddleware extends \Hyperf\HttpServer\CoreMiddleware
         $this->dispatcher = $factory->getDispatcher($serverName);
     }
 
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
-    {
-        return parent::process($request, $handler);
-    }
-
     protected function handleFound(array $routes, ServerRequestInterface $request)
     {
         if ($routes[1] instanceof Closure) {

--- a/src/rpc-server/src/Server.php
+++ b/src/rpc-server/src/Server.php
@@ -118,9 +118,7 @@ abstract class Server implements OnReceiveInterface, MiddlewareInitializerInterf
             if (! $response || ! $response instanceof ResponseInterface) {
                 $response = $this->transferToResponse($response);
             }
-            if (! $response) {
-                $this->logger->debug(sprintf('No content to response at fd[%d]', $fd));
-            } else {
+            if ($response) {
                 $server->send($fd, (string) $response);
             }
         }

--- a/src/rpc/src/Contract/DataFormatterInterface.php
+++ b/src/rpc/src/Contract/DataFormatterInterface.php
@@ -17,4 +17,6 @@ interface DataFormatterInterface
     public function formatRequest($data);
 
     public function formatResponse($data);
+
+    public function formatErrorResponse($data);
 }


### PR DESCRIPTION
1. Optimized error handling of json-rpc, and will response a standard json-rpc error object when the rpc method does not exist, fixed #145 
2. If `Hyperf\Contract\IdGeneratorInterface` exist, then the json-rpc client will generate a Request ID via IdGenerator automatically. 
3. Add support for service register and health checks of `jsonrpc` TCP protocol