### PR TITLE
Fixed `$default` is not work in method `Request::header`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - [#271](https://github.com/hyperf-cloud/hyperf/pull/271) Fixed aop only rewrite the first method in classes and method patten is not work.
 - [#285](https://github.com/hyperf-cloud/hyperf/pull/285) Fixed anonymous class should not rewrite in proxy class.
 - [#286](https://github.com/hyperf-cloud/hyperf/pull/286) Fixed not auto rollback when forgotten to commit or rollback in multi transactions.
-
+- [#292](https://github.com/hyperf-cloud/hyperf/pull/292) Fixed `$default` is not work in method `Request::header`.
 # v1.0.7 - 2019-07-26
 
 ## Fixed

--- a/src/http-server/src/Annotation/RequestMapping.php
+++ b/src/http-server/src/Annotation/RequestMapping.php
@@ -20,7 +20,6 @@ use Hyperf\Utils\Str;
  */
 class RequestMapping extends Mapping
 {
-
     public const GET = 'GET';
 
     public const POST = 'POST';

--- a/src/http-server/src/Contract/ResponseInterface.php
+++ b/src/http-server/src/Contract/ResponseInterface.php
@@ -30,7 +30,7 @@ interface ResponseInterface
      * Format data to XML and return data with Content-Type:application/xml header.
      *
      * @param array|Arrayable|Xmlable $data
-     * @param string $root The name of the root node.
+     * @param string $root the name of the root node
      */
     public function xml($data, string $root = 'root'): PsrResponseInterface;
 

--- a/src/http-server/src/CoreMiddleware.php
+++ b/src/http-server/src/CoreMiddleware.php
@@ -146,7 +146,7 @@ class CoreMiddleware implements MiddlewareInterface
     /**
      * Transfer the non-standard response content to a standard response object.
      *
-     * @param array|string|Jsonable|Arrayable $response
+     * @param array|Arrayable|Jsonable|string $response
      */
     protected function transferToResponse($response, ServerRequestInterface $request): ResponseInterface
     {

--- a/src/http-server/src/Request.php
+++ b/src/http-server/src/Request.php
@@ -150,7 +150,10 @@ class Request implements RequestInterface
      */
     public function header(string $key, $default = null)
     {
-        return $this->getHeaderLine($key) ?? $default;
+        if (! $this->hasHeader($key)) {
+            return $default;
+        }
+        return $this->getHeaderLine($key);
     }
 
     /**

--- a/src/http-server/tests/MappingAnnotationTest.php
+++ b/src/http-server/tests/MappingAnnotationTest.php
@@ -1,14 +1,26 @@
 <?php
 
-namespace HyperfTest\HttpServer;
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf-cloud/hyperf/blob/master/LICENSE
+ */
 
+namespace HyperfTest\HttpServer;
 
 use Hyperf\HttpServer\Annotation\RequestMapping;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @internal
+ * @coversNothing
+ */
 class MappingAnnotationTest extends TestCase
 {
-
     public function testRequestMapping()
     {
         $mapping = new RequestMapping([]);
@@ -37,7 +49,7 @@ class MappingAnnotationTest extends TestCase
     {
         $mapping = new RequestMapping([
             'methods' => [
-                'GET', 'POST ', 'put'
+                'GET', 'POST ', 'put',
             ],
             'path' => $path = '/foo',
         ]);

--- a/src/http-server/tests/RequestTest.php
+++ b/src/http-server/tests/RequestTest.php
@@ -48,12 +48,16 @@ class RequestTest extends TestCase
     public function testRequestHeaderDefaultValue()
     {
         $psrRequest = Mockery::mock(ServerRequestInterface::class);
-        $psrRequest->shouldReceive('hasHeader')->andReturn(false);
+        $psrRequest->shouldReceive('hasHeader')->with('Version')->andReturn(false);
+        $psrRequest->shouldReceive('hasHeader')->with('Hyperf-Version')->andReturn(true);
+        $psrRequest->shouldReceive('getHeaderLine')->with('Hyperf-Version')->andReturn('v1.0');
         Context::set(ServerRequestInterface::class, $psrRequest);
 
         $psrRequest = new Request();
         $res = $psrRequest->header('Version', 'v1');
-
         $this->assertSame('v1', $res);
+
+        $res = $psrRequest->header('Hyperf-Version', 'v0');
+        $this->assertSame('v1.0', $res);
     }
 }

--- a/src/http-server/tests/RequestTest.php
+++ b/src/http-server/tests/RequestTest.php
@@ -44,4 +44,16 @@ class RequestTest extends TestCase
         $this->assertFalse($request->hasFile('file2'));
         $this->assertInstanceOf(UploadedFile::class, $request->file('file'));
     }
+
+    public function testRequestHeaderDefaultValue()
+    {
+        $psrRequest = Mockery::mock(ServerRequestInterface::class);
+        $psrRequest->shouldReceive('hasHeader')->andReturn(false);
+        Context::set(ServerRequestInterface::class, $psrRequest);
+
+        $psrRequest = new Request();
+        $res = $psrRequest->header('Version', 'v1');
+
+        $this->assertSame('v1', $res);
+    }
 }

--- a/src/http-server/tests/ResponseTest.php
+++ b/src/http-server/tests/ResponseTest.php
@@ -116,6 +116,7 @@ class ResponseTest extends TestCase
         // Xmlable
         $xmlable = new class($expected) implements Xmlable {
             private $result;
+
             public function __construct($result)
             {
                 $this->result = $result;
@@ -128,5 +129,4 @@ class ResponseTest extends TestCase
         };
         $this->assertSame($expected, $reflectionMethod->invoke($response, $xmlable));
     }
-
 }

--- a/src/http-server/tests/Stub/CoreMiddlewareStub.php
+++ b/src/http-server/tests/Stub/CoreMiddlewareStub.php
@@ -27,5 +27,4 @@ class CoreMiddlewareStub extends CoreMiddleware
     {
         return new Response();
     }
-
 }


### PR DESCRIPTION
fix https://github.com/hyperf-cloud/hyperf/issues/291