### PR TITLE
Optimized async queue and amqp consumer.

### DIFF
--- a/src/amqp/src/Consumer.php
+++ b/src/amqp/src/Consumer.php
@@ -16,6 +16,7 @@ use Hyperf\Amqp\Exception\MessageException;
 use Hyperf\Amqp\Message\ConsumerMessageInterface;
 use Hyperf\Amqp\Message\MessageInterface;
 use Hyperf\Amqp\Pool\PoolFactory;
+use Hyperf\ExceptionHandler\Formatter\FormatterInterface;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Message\AMQPMessage;
 use Psr\Container\ContainerInterface;
@@ -64,19 +65,30 @@ class Consumer extends Builder
                 /** @var AMQPChannel $channel */
                 $channel = $message->delivery_info['channel'];
                 $deliveryTag = $message->delivery_info['delivery_tag'];
-                try {
-                    $result = $consumerMessage->consume($data);
-                    if ($result === Result::ACK) {
-                        $this->logger->debug($deliveryTag . ' acked.');
-                        return $channel->basic_ack($deliveryTag);
+                [$result] = parallel([function () use ($consumerMessage, $data) {
+                    try {
+                        return $consumerMessage->consume($data);
+                    } catch (Throwable $exception) {
+                        if ($this->container->has(FormatterInterface::class)) {
+                            $formatter = $this->container->get(FormatterInterface::class);
+                            $this->logger->error($formatter->format($exception));
+                        } else {
+                            $this->logger->error($exception->getMessage());
+                        }
+
+                        return Result::DROP;
                     }
-                    if ($consumerMessage->isRequeue() && $result === Result::REQUEUE) {
-                        $this->logger->debug($deliveryTag . ' requeued.');
-                        return $channel->basic_reject($deliveryTag, true);
-                    }
-                } catch (Throwable $exception) {
-                    $this->logger->debug($exception->getMessage());
+                }]);
+
+                if ($result === Result::ACK) {
+                    $this->logger->debug($deliveryTag . ' acked.');
+                    return $channel->basic_ack($deliveryTag);
                 }
+                if ($consumerMessage->isRequeue() && $result === Result::REQUEUE) {
+                    $this->logger->debug($deliveryTag . ' requeued.');
+                    return $channel->basic_reject($deliveryTag, true);
+                }
+
                 $this->logger->debug($deliveryTag . ' rejected.');
                 $channel->basic_reject($deliveryTag, false);
             }

--- a/src/async-queue/src/Job.php
+++ b/src/async-queue/src/Job.php
@@ -17,7 +17,7 @@ abstract class Job implements JobInterface
     /**
      * @var int
      */
-    protected $maxAttempts = 1;
+    protected $maxAttempts = 0;
 
     public function getMaxAttempts(): int
     {

--- a/src/async-queue/src/Message.php
+++ b/src/async-queue/src/Message.php
@@ -36,7 +36,7 @@ class Message implements MessageInterface
 
     public function attempts(): bool
     {
-        if ($this->job->getMaxAttempts() > ++$this->attempts) {
+        if ($this->job->getMaxAttempts() > $this->attempts++) {
             return true;
         }
         return false;


### PR DESCRIPTION
- Let message queues run in sub-coroutines.
- Fixed async queue attempts twice to handle message, but only once actually.

fix https://github.com/hyperf-cloud/hyperf/issues/294
fix https://github.com/hyperf-cloud/hyperf/issues/287