### PR TITLE
Update task.md

### DIFF
--- a/doc/zh/task.md
+++ b/doc/zh/task.md
@@ -64,7 +64,7 @@ class MethodTask
 
 $container = ApplicationContext::getContainer();
 $exec = $container->get(TaskExecutor::class);
-$result = $exec->execute(new Task([MethodTask::class, 'handle'], Coroutine::id()));
+$result = $exec->execute(new Task([MethodTask::class, 'handle'], [Coroutine::id()]));
 
 ```
 


### PR DESCRIPTION
这个地方应该是传递一个数组。

```
PHP Fatal error:  Uncaught TypeError: Argument 2 passed to Hyperf\Task\Task::__construct() must be of the type array, int given, called in /mnt/hgfs/F/php/hyperf-im/app/Http/Ws/ChatLogController.php on line 39 and defined in /mnt/hgfs/F/php/hyperf-im/vendor/hyperf/task/src/Task.php:27
Stack trace:
#0 /mnt/hgfs/F/php/hyperf-im/app/Http/Ws/ChatLogController.php(39): Hyperf\Task\Task->__construct(Array, 6)
#1 /mnt/hgfs/F/php/hyperf-im/app/Http/Ws/MessageController.php(40): App\Http\Ws\ChatLogController->saveChatLog()
#2 /mnt/hgfs/F/php/hyperf-im/app/Http/Ws/RoomController.php(48): App\Http\Ws\MessageController->formatMsgData(Object(stdClass))
#3 /mnt/hgfs/F/php/hyperf-im/app/Http/Ws/RoomController.php(34): App\Http\Ws\RoomController->sendMsg(Object(stdClass))
#4 /mnt/hgfs/F/php/hyperf-im/app/Http/Ws/RoomWebSocket.php(28): App\Http\Ws\RoomController->checkData(Object(Swoole\WebSocket\Frame), Object(Swoole\WebSocket\Server))
#5 /mnt/hgfs/F/php/hyperf-im/vendor/hyperf/websocket-server/src/Server.php(165): App\Http\Ws\RoomWebSocket-> in /mnt/hgfs/F/php/hyperf-im/vendor/hyperf/task/src/Task.php on line 27
```