### PR TITLE
Update task.md

### DIFF
--- a/doc/zh/task.md
+++ b/doc/zh/task.md
@@ -52,7 +52,7 @@ use Hyperf\Task\Task;
 
 class MethodTask
 {
-    public function handle($cid)
+    public static function handle($cid)
     {
         return [
             'worker.cid' => $cid,


### PR DESCRIPTION
主动投递时，投递的到 task 的方法应该是静态的

```
PHP Deprecated:  Non-static method App\Http\Ws\ChatLogController::handle() should not be called statically in /mnt/hgfs/F/php/hyperf-im/vendor/hyperf/utils/src/Functions.php on line 274
```