### PR TITLE
Fix json-rpc error response error

### DIFF
--- a/src/json-rpc/src/HttpServer.php
+++ b/src/json-rpc/src/HttpServer.php
@@ -64,14 +64,15 @@ class HttpServer extends Server
     {
         // Initialize PSR-7 Request and Response objects.
         $psr7Request = Psr7Request::loadFromSwooleRequest($request);
+        Context::set(ResponseInterface::class, $psr7Response = new Psr7Response($response));
         if (! $this->isHealthCheck($psr7Request)) {
             if (strpos($psr7Request->getHeaderLine('content-type'), 'application/json') === false) {
-                $this->responseBuilder->buildErrorResponse($request, -32700);
+                $psr7Response = $this->responseBuilder->buildErrorResponse($psr7Request, -32700);
             }
             // @TODO Optimize the error handling of encode.
             $content = $this->packer->unpack($psr7Request->getBody()->getContents());
             if (! isset($content['jsonrpc'], $content['method'], $content['params'])) {
-                $this->responseBuilder->buildErrorResponse($request, -32600);
+                $psr7Response = $this->responseBuilder->buildErrorResponse($psr7Request, -32600);
             }
         }
         $psr7Request = $psr7Request->withUri($psr7Request->getUri()->withPath($content['method'] ?? '/'))
@@ -79,7 +80,7 @@ class HttpServer extends Server
             ->withAttribute('data', $content ?? [])
             ->withAttribute('request_id', $content['id'] ?? null);
         Context::set(ServerRequestInterface::class, $psr7Request);
-        Context::set(ResponseInterface::class, $psr7Response = new Psr7Response($response));
+        Context::set(ResponseInterface::class, $psr7Response);
         return [$psr7Request, $psr7Response];
     }
 


### PR DESCRIPTION
修改构造 json-rpc 错误请求代码错误：request 参数类型不对，而且此时 response 未加入到 Context 中，返回的 response 对象也需要重新设置到 Context 中