### PR TITLE
Hidden DI scan message when paths is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - [#321](https://github.com/hyperf-cloud/hyperf/pull/321) Added custom object support for controller parameters in http-server.
 - [#324](https://github.com/hyperf-cloud/hyperf/pull/324) Added NodeRequestIdGenerator, an implementation of `Hyperf\Contract\IdGeneratorInterface`
 
+## Changed
+
+- [#330](https://github.com/hyperf-cloud/hyperf/pull/330) Hidden DI scan message when paths is empty.
+
 ## Fixed
 
 - [#325](https://github.com/hyperf-cloud/hyperf/pull/325) Fixed consul service check the same service registration status more than one times.

--- a/src/di/src/Definition/DefinitionSource.php
+++ b/src/di/src/Definition/DefinitionSource.php
@@ -216,6 +216,9 @@ class DefinitionSource implements DefinitionSourceInterface
 
     private function scan(array $paths): bool
     {
+        if (empty($paths)) {
+            return true;
+        }
         $pathsHash = md5(implode(',', $paths));
         if ($this->hasAvailableCache($paths, $pathsHash, $this->cachePath)) {
             $this->printLn('Detected an available cache, skip the scan process.');


### PR DESCRIPTION
只要构造 Container 就会有这个信息打印出来：
```
Scanning ...
Scan completed.
```
单元测试时不需要显示这个信息。