### PR TITLE
fix tracer middeware bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## Fixed
 
 - [#325](https://github.com/hyperf-cloud/hyperf/pull/325) Fixed consul service check the same service registration status more than one times.
+- [#332](https://github.com/hyperf-cloud/hyperf/pull/332) Fixed type error in `Hyperf\Tracer\Middleware\TraceMiddeware`.
 
 # v1.0.9 - 2019-08-03
 

--- a/src/tracer/publish/opentracing.php
+++ b/src/tracer/publish/opentracing.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf-cloud/hyperf/blob/master/LICENSE
  */
+
 use Zipkin\Samplers\BinarySampler;
 
 return [

--- a/src/tracer/src/Middleware/TraceMiddeware.php
+++ b/src/tracer/src/Middleware/TraceMiddeware.php
@@ -59,7 +59,7 @@ class TraceMiddeware implements MiddlewareInterface
     {
         $uri = $request->getUri();
         $span = $this->tracing->span('request', SERVER);
-        $span->tag('coroutine.id', Coroutine::id());
+        $span->tag('coroutine.id', (string) Coroutine::id());
         $span->tag('request.path', (string) $uri);
         $span->tag('request.method', $request->getMethod());
         foreach ($request->getHeaders() as $key => $value) {


### PR DESCRIPTION
~~~ 
[ERROR] Argument 2 passed to Zipkin\RealSpan::tag() must be of the type string, int given, called 
~~~