### PR TITLE
Fix configuration does not take effect in real time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#325](https://github.com/hyperf-cloud/hyperf/pull/325) Fixed consul service check the same service registration status more than one times.
 - [#332](https://github.com/hyperf-cloud/hyperf/pull/332) Fixed type error in `Hyperf\Tracer\Middleware\TraceMiddeware`.
 - [#333](https://github.com/hyperf-cloud/hyperf/pull/333) Fixed Function Redis::delete() is deprecated.
+- [#334](https://github.com/hyperf-cloud/hyperf/pull/334) Fixed configuration of aliyun acm is not work expected.
 
 # v1.0.9 - 2019-08-03
 

--- a/src/config-aliyun-acm/src/Process/ConfigFetcherProcess.php
+++ b/src/config-aliyun-acm/src/Process/ConfigFetcherProcess.php
@@ -69,7 +69,7 @@ class ConfigFetcherProcess extends AbstractProcess
             $config = $this->client->pull();
             if ($config !== $this->cacheConfig) {
                 if ($this->cacheConfig !== null) {
-                    $diff = array_diff($this->cacheConfig ?? [], $config);
+                    $diff = array_diff($config, $this->cacheConfig ?? []);
                 } else {
                     $diff = $config;
                 }

--- a/src/config-aliyun-acm/src/Process/ConfigFetcherProcess.php
+++ b/src/config-aliyun-acm/src/Process/ConfigFetcherProcess.php
@@ -68,15 +68,10 @@ class ConfigFetcherProcess extends AbstractProcess
         while (true) {
             $config = $this->client->pull();
             if ($config !== $this->cacheConfig) {
-                if ($this->cacheConfig !== null) {
-                    $diff = array_diff($config, $this->cacheConfig ?? []);
-                } else {
-                    $diff = $config;
-                }
                 $this->cacheConfig = $config;
                 $workerCount = $this->server->setting['worker_num'] + $this->server->setting['task_worker_num'] - 1;
                 for ($workerId = 0; $workerId <= $workerCount; ++$workerId) {
-                    $this->server->sendMessage(new PipeMessage($diff), $workerId);
+                    $this->server->sendMessage(new PipeMessage($config), $workerId);
                 }
             }
             sleep($this->config->get('aliyun_acm.interval', 5));


### PR DESCRIPTION
Fix configuration does not take effect in real time

The array_diff difference value is obtained from the first parameter. Therefore, the modification of the configuration file needs to wait for the next time to take effect.
![image](https://user-images.githubusercontent.com/7540584/62486692-8900a400-b7f2-11e9-9ef2-3f3106c5023e.png)
