### PR TITLE
Fixed 500 response when key of header is not string.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#332](https://github.com/hyperf-cloud/hyperf/pull/332) Fixed type error in `Hyperf\Tracer\Middleware\TraceMiddeware`.
 - [#333](https://github.com/hyperf-cloud/hyperf/pull/333) Fixed Function Redis::delete() is deprecated.
 - [#334](https://github.com/hyperf-cloud/hyperf/pull/334) Fixed configuration of aliyun acm is not work expected.
+- [#337](https://github.com/hyperf-cloud/hyperf/pull/337) Fixed 500 response when key of header is not string.
 
 # v1.0.9 - 2019-08-03
 

--- a/composer.json
+++ b/composer.json
@@ -179,6 +179,7 @@
             "HyperfTest\\Etcd\\": "src/etcd/tests/",
             "HyperfTest\\Event\\": "src/event/tests/",
             "HyperfTest\\Guzzle\\": "src/guzzle/tests/",
+            "HyperfTest\\HttpMessage\\": "src/http-message/tests/",
             "HyperfTest\\HttpServer\\": "src/http-server/tests/",
             "HyperfTest\\JsonRpc\\": "src/json-rpc/tests/",
             "HyperfTest\\LoadBalancer\\": "src/load-balancer/tests/",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,6 +22,7 @@
             <directory suffix="Test.php">./src/elasticsearch/tests</directory>
             <directory suffix="Test.php">./src/event/tests</directory>
             <directory suffix="Test.php">./src/guzzle/tests</directory>
+            <directory suffix="Test.php">./src/http-message/tests</directory>
             <directory suffix="Test.php">./src/http-server/tests</directory>
             <directory suffix="Test.php">./src/json-rpc/tests</directory>
             <directory suffix="Test.php">./src/logger/tests</directory>

--- a/src/http-message/composer.json
+++ b/src/http-message/composer.json
@@ -24,6 +24,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "HyperfTest\\HttpMessage\\": "tests/"
         }
     },
     "config": {

--- a/src/http-message/src/Base/MessageTrait.php
+++ b/src/http-message/src/Base/MessageTrait.php
@@ -353,6 +353,8 @@ trait MessageTrait
             }
 
             $value = $this->trimHeaderValues($value);
+            $header = (string) $header;
+
             $normalized = strtolower($header);
             if (isset($this->headerNames[$normalized])) {
                 $header = $this->headerNames[$normalized];

--- a/src/http-message/src/Base/MessageTrait.php
+++ b/src/http-message/src/Base/MessageTrait.php
@@ -380,7 +380,7 @@ trait MessageTrait
     private function trimHeaderValues(array $values)
     {
         return array_map(function ($value) {
-            return trim($value, " \t");
+            return trim((string) $value, " \t");
         }, $values);
     }
 }

--- a/src/http-message/tests/MessageTraitTest.php
+++ b/src/http-message/tests/MessageTraitTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf-cloud/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\HttpMessage;
+
+use Hyperf\HttpMessage\Base\Request;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class MessageTraitTest extends TestCase
+{
+    public function testSetHeaders()
+    {
+        $token = uniqid();
+        $id = rand(1000, 9999);
+        $request = new Request('GET', '/', [
+            'X-Token' => $token,
+            'X-Id' => $id,
+            'Version' => 1.0,
+            1000 => 1000,
+        ]);
+
+        $this->assertSame($token, $request->getHeaderLine('X-Token'));
+        $this->assertSame((string) $id, $request->getHeaderLine('X-Id'));
+        $this->assertSame('1', $request->getHeaderLine('Version'));
+        $this->assertSame('1000', $request->getHeaderLine('1000'));
+    }
+}


### PR DESCRIPTION
fix https://github.com/hyperf-cloud/hyperf/issues/322