### PR TITLE
解决重复key会导致在深度合并时将字符串转换成数组

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#333](https://github.com/hyperf-cloud/hyperf/pull/333) Fixed Function Redis::delete() is deprecated.
 - [#334](https://github.com/hyperf-cloud/hyperf/pull/334) Fixed configuration of aliyun acm is not work expected.
 - [#337](https://github.com/hyperf-cloud/hyperf/pull/337) Fixed 500 response when key of header is not string.
+- [#338](https://github.com/hyperf-cloud/hyperf/pull/338) Fixed `ProviderConfig::load` will convert array when dependencies has the same key.
 
 # v1.0.9 - 2019-08-03
 

--- a/composer.json
+++ b/composer.json
@@ -168,6 +168,7 @@
             "HyperfTest\\ConfigAliyunAcm\\": "src/config-aliyun-acm/tests/",
             "HyperfTest\\ConfigApollo\\": "src/config-apollo/tests/",
             "HyperfTest\\ConfigEtcd\\": "src/config-etcd/tests/",
+            "HyperfTest\\Config\\": "src/config/tests/",
             "HyperfTest\\Constants\\": "src/constants/tests/",
             "HyperfTest\\Consul\\": "src/consul/tests/",
             "HyperfTest\\Crontab\\": "src/crontab/tests/",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,7 @@
             <directory suffix="Test.php">./src/amqp/tests</directory>
             <directory suffix="Test.php">./src/async-queue/tests</directory>
             <directory suffix="Test.php">./src/cache/tests</directory>
+            <directory suffix="Test.php">./src/config/tests</directory>
             <directory suffix="Test.php">./src/constants/tests</directory>
             <directory suffix="Test.php">./src/consul/tests</directory>
             <directory suffix="Test.php">./src/database/tests</directory>

--- a/src/config/.gitattributes
+++ b/src/config/.gitattributes
@@ -1,0 +1,1 @@
+/tests export-ignore

--- a/src/config/composer.json
+++ b/src/config/composer.json
@@ -44,6 +44,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "HyperfTest\\Config\\": "tests/"
         }
     },
     "config": {

--- a/src/config/src/ProviderConfig.php
+++ b/src/config/src/ProviderConfig.php
@@ -35,7 +35,7 @@ class ProviderConfig
     public static function load(): array
     {
         if (! static::$privoderConfigs) {
-            $providers = Composer::getMergedExtra('hyperf')['config'];
+            $providers = Composer::getMergedExtra('hyperf')['config'] ?? [];
             $providerConfigs = [];
             foreach ($providers ?? [] as $provider) {
                 if (is_string($provider) && class_exists($provider) && method_exists($provider, '__invoke')) {
@@ -49,7 +49,12 @@ class ProviderConfig
         return static::$privoderConfigs;
     }
 
-    public static function merge(...$arrays)
+    public static function clear(): void
+    {
+        static::$privoderConfigs = [];
+    }
+
+    protected static function merge(...$arrays): array
     {
         $result = array_merge_recursive(...$arrays);
         if (isset($result['dependencies'])) {
@@ -58,10 +63,5 @@ class ProviderConfig
         }
 
         return $result;
-    }
-
-    public static function clear(): void
-    {
-        static::$privoderConfigs = [];
     }
 }

--- a/src/config/src/ProviderConfig.php
+++ b/src/config/src/ProviderConfig.php
@@ -40,10 +40,7 @@ class ProviderConfig
             foreach ($providers ?? [] as $provider) {
                 if (is_string($provider) && class_exists($provider) && method_exists($provider, '__invoke')) {
                     $providerConfig = (new $provider())();
-                    $config = array_merge_recursive($config, $providerConfig);
-                    if (isset($providerConfig['dependencies'])) {
-                        $config['dependencies'] = array_merge($config['dependencies'], $providerConfig['dependencies']);
-                    }
+                    $config = static::merge($config, $providerConfig);
                 }
             }
 
@@ -53,7 +50,18 @@ class ProviderConfig
         return static::$privoderConfigs;
     }
 
-    public function clear(): void
+    public static function merge(...$arrays)
+    {
+        $result = array_merge_recursive(...$arrays);
+        if (isset($result['dependencies'])) {
+            $dependencies = array_column($arrays, 'dependencies');
+            $result['dependencies'] = array_merge(...$dependencies);
+        }
+
+        return $result;
+    }
+
+    public static function clear(): void
     {
         static::$privoderConfigs = [];
     }

--- a/src/config/src/ProviderConfig.php
+++ b/src/config/src/ProviderConfig.php
@@ -34,7 +34,7 @@ class ProviderConfig
      */
     public static function load(): array
     {
-        if (!static::$privoderConfigs) {
+        if (! static::$privoderConfigs) {
             $providers = Composer::getMergedExtra('hyperf')['config'];
             $providerConfigs = [];
             foreach ($providers ?? [] as $provider) {

--- a/src/config/src/ProviderConfig.php
+++ b/src/config/src/ProviderConfig.php
@@ -41,6 +41,9 @@ class ProviderConfig
                 if (is_string($provider) && class_exists($provider) && method_exists($provider, '__invoke')) {
                     $providerConfig = (new $provider())();
                     $config = array_merge_recursive($config, $providerConfig);
+                    if (isset($providerConfig['dependencies'])) {
+                        $config['dependencies'] = array_merge($config['dependencies'], $providerConfig['dependencies']);
+                    }
                 }
             }
 

--- a/src/config/src/ProviderConfig.php
+++ b/src/config/src/ProviderConfig.php
@@ -34,18 +34,17 @@ class ProviderConfig
      */
     public static function load(): array
     {
-        if (! static::$privoderConfigs) {
-            $config = [];
+        if (!static::$privoderConfigs) {
             $providers = Composer::getMergedExtra('hyperf')['config'];
+            $providerConfigs = [];
             foreach ($providers ?? [] as $provider) {
                 if (is_string($provider) && class_exists($provider) && method_exists($provider, '__invoke')) {
-                    $providerConfig = (new $provider())();
-                    $config = static::merge($config, $providerConfig);
+                    $providerConfigs[] = (new $provider())();
                 }
             }
 
-            static::$privoderConfigs = $config;
-            unset($config, $providerConfig);
+            static::$privoderConfigs = static::merge(...$providerConfigs);
+            unset($providerConfigs);
         }
         return static::$privoderConfigs;
     }

--- a/src/config/src/ProviderConfig.php
+++ b/src/config/src/ProviderConfig.php
@@ -36,15 +36,7 @@ class ProviderConfig
     {
         if (! static::$privoderConfigs) {
             $providers = Composer::getMergedExtra('hyperf')['config'] ?? [];
-            $providerConfigs = [];
-            foreach ($providers ?? [] as $provider) {
-                if (is_string($provider) && class_exists($provider) && method_exists($provider, '__invoke')) {
-                    $providerConfigs[] = (new $provider())();
-                }
-            }
-
-            static::$privoderConfigs = static::merge(...$providerConfigs);
-            unset($providerConfigs);
+            static::$privoderConfigs = static::loadProviders($providers);
         }
         return static::$privoderConfigs;
     }
@@ -52,6 +44,18 @@ class ProviderConfig
     public static function clear(): void
     {
         static::$privoderConfigs = [];
+    }
+
+    protected static function loadProviders(array $providers): array
+    {
+        $providerConfigs = [];
+        foreach ($providers ?? [] as $provider) {
+            if (is_string($provider) && class_exists($provider) && method_exists($provider, '__invoke')) {
+                $providerConfigs[] = (new $provider())();
+            }
+        }
+
+        return static::merge(...$providerConfigs);
     }
 
     protected static function merge(...$arrays): array

--- a/src/config/tests/ProviderConfigTest.php
+++ b/src/config/tests/ProviderConfigTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf-cloud/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Config;
+
+use Hyperf\Config\ProviderConfig;
+use Hyperf\Utils\Composer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class ProviderConfigTest extends TestCase
+{
+    public function testProviderConfigMerge()
+    {
+        $c1 = [
+            'listeners' => ['L1'],
+            'dependencies' => [
+                'D1' => 'D1',
+                'D2' => 'D2',
+            ],
+        ];
+
+        $c2 = [
+            'listeners' => ['L2'],
+            'dependencies' => [
+                'D1' => 'D1',
+                'D2' => 'D3',
+            ],
+        ];
+
+        $c3 = [
+            'listeners' => ['L2'],
+            'dependencies' => [
+                'D1' => 'D1',
+                'D3' => 'D3',
+                'D4' => 'D4',
+            ],
+        ];
+
+        $result = ProviderConfig::merge($c1, $c2, $c3);
+
+        $this->assertSame(['D1' => 'D1', 'D2' => 'D3', 'D3' => 'D3', 'D4' => 'D4'], $result['dependencies']);
+    }
+}

--- a/src/config/tests/ProviderConfigTest.php
+++ b/src/config/tests/ProviderConfigTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace HyperfTest\Config;
 
 use Hyperf\Config\ProviderConfig;
-use Hyperf\Utils\Composer;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/src/config/tests/ProviderConfigTest.php
+++ b/src/config/tests/ProviderConfigTest.php
@@ -118,7 +118,7 @@ class ProviderConfigTest extends TestCase
         ]);
 
         foreach ($res['dependencies'] as $dependency) {
-            $this->assertIsCallable($dependency);
+            $this->assertTrue(is_string($dependency) || is_callable($dependency));
         }
     }
 }

--- a/src/config/tests/ProviderConfigTest.php
+++ b/src/config/tests/ProviderConfigTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace HyperfTest\Config;
 
-use Hyperf\Config\ProviderConfig;
+use HyperfTest\Config\Stub\ProviderConfig;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -51,5 +51,40 @@ class ProviderConfigTest extends TestCase
         $result = ProviderConfig::merge($c1, $c2, $c3);
 
         $this->assertSame(['D1' => 'D1', 'D2' => 'D3', 'D3' => 'D3', 'D4' => 'D4'], $result['dependencies']);
+    }
+
+    public function testProviderConfigNotHaveDependencies()
+    {
+        $c1 = [
+            'listeners' => ['L1'],
+            'dependencies' => [
+                'D1' => 'D1',
+                'D2' => 'D2',
+            ],
+        ];
+
+        $c2 = [
+            'listeners' => ['L2'],
+        ];
+
+        $result = ProviderConfig::merge($c1, $c2);
+        $this->assertSame(['D1' => 'D1', 'D2' => 'D2'], $result['dependencies']);
+        $this->assertSame(['L1', 'L2'], $result['listeners']);
+    }
+
+    public function testProviderConfigHaveNull()
+    {
+        $c1 = [
+            'listeners' => ['L1'],
+        ];
+
+        $c2 = [
+            'listeners' => [value(function () {
+                return null;
+            })],
+        ];
+
+        $result = ProviderConfig::merge($c1, $c2);
+        $this->assertSame(['L1', null], $result['listeners']);
     }
 }

--- a/src/config/tests/Stub/Foo.php
+++ b/src/config/tests/Stub/Foo.php
@@ -12,15 +12,17 @@ declare(strict_types=1);
 
 namespace HyperfTest\Config\Stub;
 
-class ProviderConfig extends \Hyperf\Config\ProviderConfig
+class Foo
 {
-    public static function loadProviders(array $providers): array
+    public $id;
+
+    public function __construct($id = 0)
     {
-        return parent::loadProviders($providers);
+        $this->id = $id;
     }
 
-    public static function merge(...$arrays): array
+    public static function make()
     {
-        return parent::merge(...$arrays);
+        return new self(2);
     }
 }

--- a/src/config/tests/Stub/FooConfigProvider.php
+++ b/src/config/tests/Stub/FooConfigProvider.php
@@ -22,6 +22,7 @@ class FooConfigProvider
                     return new Foo(1);
                 },
                 'Foo2' => [Foo::class, 'make'],
+                'Foo3' => Foo::class,
             ],
         ];
     }

--- a/src/config/tests/Stub/FooConfigProvider.php
+++ b/src/config/tests/Stub/FooConfigProvider.php
@@ -12,15 +12,17 @@ declare(strict_types=1);
 
 namespace HyperfTest\Config\Stub;
 
-class ProviderConfig extends \Hyperf\Config\ProviderConfig
+class FooConfigProvider
 {
-    public static function loadProviders(array $providers): array
+    public function __invoke()
     {
-        return parent::loadProviders($providers);
-    }
-
-    public static function merge(...$arrays): array
-    {
-        return parent::merge(...$arrays);
+        return [
+            'dependencies' => [
+                'Foo' => function () {
+                    return new Foo(1);
+                },
+                'Foo2' => [Foo::class, 'make'],
+            ],
+        ];
     }
 }

--- a/src/config/tests/Stub/ProviderConfig.php
+++ b/src/config/tests/Stub/ProviderConfig.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf-cloud/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Config\Stub;
+
+class ProviderConfig extends \Hyperf\Config\ProviderConfig
+{
+    public static function merge(...$arrays): array
+    {
+        return parent::merge(...$arrays);
+    }
+}


### PR DESCRIPTION
解决重复key会导致在深度合并时将字符串转换成数组