### PR TITLE
logger config support use logger level name instead of integer constants

### DIFF
--- a/src/logger/src/LoggerFactory.php
+++ b/src/logger/src/LoggerFactory.php
@@ -73,7 +73,7 @@ class LoggerFactory
         $handlerConstructor = $config['handler']['constructor'];
 
         /** @var HandlerInterface $handler */
-        $handler = make($handlerClass, $handlerConstructor);
+        $handler = make($handlerClass, $this->normalizeParameters($handlerConstructor));
 
         $formatterClass = $config['formatter']['class'];
         $formatterConstructor = $config['formatter']['constructor'];
@@ -84,5 +84,18 @@ class LoggerFactory
         $handler->setFormatter($formatter);
 
         return $handler;
+    }
+
+    private function normalizeParameters(array $parameters): array
+    {
+        if (isset($parameters['level']) && is_string($parameters['level'])) {
+            $name = '\\Monolog\\Logger::' . strtoupper($parameters['level']);
+            if (defined($name)) {
+                $parameters['level'] = constant($name);
+            } else {
+                throw new \InvalidArgumentException("Unknown logger level '{$parameters['level']}'");
+            }
+        }
+        return $parameters;
     }
 }

--- a/src/logger/tests/LoggerFactoryTest.php
+++ b/src/logger/tests/LoggerFactoryTest.php
@@ -53,6 +53,34 @@ class LoggerFactoryTest extends TestCase
         $this->assertInstanceOf(\Hyperf\Logger\Logger::class, $logger);
     }
 
+    public function testLoggerLevelOfStringValue()
+    {
+        $container = Mockery::mock(ContainerInterface::class);
+        $container->shouldReceive('get')->once()->with(ConfigInterface::class)->andReturn(new Config([
+            'logger' => [
+                'default' => [
+                    'handler' => [
+                        'class' => \Monolog\Handler\StreamHandler::class,
+                        'constructor' => [
+                            'stream' => BASE_PATH . '/runtime/logs/hyperf.log',
+                            'level' => 'info',
+                        ],
+                    ],
+                    'formatter' => [
+                        'class' => \Monolog\Formatter\LineFormatter::class,
+                        'constructor' => [],
+                    ],
+                ],
+            ],
+        ]));
+        ApplicationContext::setContainer($container);
+        $factory = new LoggerFactory($container);
+        /** @var Logger $logger */
+        $logger = $factory->get('app');
+        $handler = $logger->getHandlers()[0];
+        $this->assertEquals(Logger::INFO, $handler->getLevel());
+    }
+
     private function mockContainer()
     {
         $container = Mockery::mock(ContainerInterface::class);


### PR DESCRIPTION
logger level 通常会在 .env 文件中定义，如果使用整数很不直观，使用名字配置更为合理