### PR TITLE
修复模型生成时 mysql 版本兼容问题

### DIFF
--- a/src/database/src/Commands/Ast/ModelUpdateVistor.php
+++ b/src/database/src/Commands/Ast/ModelUpdateVistor.php
@@ -52,7 +52,7 @@ class ModelUpdateVistor extends NodeVisitorAbstract
     {
         $items = [];
         foreach ($this->columns as $column) {
-            $items[] = new Node\Expr\ArrayItem(new Node\Scalar\String_($column['column_name']));
+            $items[] = new Node\Expr\ArrayItem(new Node\Scalar\String_($column['column_name'] ?? $column['COLUMN_NAME']));
         }
 
         $node->default = new Node\Expr\Array_($items, [
@@ -65,9 +65,9 @@ class ModelUpdateVistor extends NodeVisitorAbstract
     {
         $items = [];
         foreach ($this->columns as $column) {
-            $name = $column['column_name'];
+            $name = $column['column_name'] ?? $column['COLUMN_NAME'];
             $type = $column['cast'] ?? null;
-            if ($type || $type = $this->formatDatabaseType($column['data_type'])) {
+            if ($type || $type = $this->formatDatabaseType($column['data_type'] ?? $column['DATA_TYPE'])) {
                 $items[] = new Node\Expr\ArrayItem(
                     new Node\Scalar\String_($type),
                     new Node\Scalar\String_($name)
@@ -83,9 +83,9 @@ class ModelUpdateVistor extends NodeVisitorAbstract
 
     protected function getProperty($column): array
     {
-        $name = $column['column_name'];
+        $name = $column['column_name'] ?? $column['COLUMN_NAME'];
 
-        $type = $this->formatPropertyType($column['data_type'], $column['cast'] ?? null);
+        $type = $this->formatPropertyType($column['data_type'] ?? $column['DATA_TYPE'], $column['cast'] ?? null);
 
         return [$name, $type];
     }

--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -180,7 +180,6 @@ class ModelCommand extends Command
                 $casts[$date] = 'datetime';
             }
         }
-//        var_dump($columns);
         foreach ($columns as $key => $value) {
             $columns[$key]['cast'] = $casts[$value['column_name'] ?? $value['COLUMN_NAME']] ?? null;
         }

--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -175,13 +175,12 @@ class ModelCommand extends Command
         if (! $forceCasts) {
             $casts = $model->getCasts();
         }
-
         foreach ($dates as $date) {
             if (! isset($casts[$date])) {
                 $casts[$date] = 'datetime';
             }
         }
-
+//        var_dump($columns);
         foreach ($columns as $key => $value) {
             $columns[$key]['cast'] = $casts[$value['column_name'] ?? $value['COLUMN_NAME']] ?? null;
         }

--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -183,7 +183,7 @@ class ModelCommand extends Command
         }
 
         foreach ($columns as $key => $value) {
-            $columns[$key]['cast'] = $casts[$value['column_name']] ?? null;
+            $columns[$key]['cast'] = $casts[$value['column_name'] ?? $value['COLUMN_NAME']] ?? null;
         }
 
         return $columns;


### PR DESCRIPTION
```
兼容 mysql 8.0 版本，column_name 和 data_type 字段被 upper
```
![https://oss.iacblog.com/github/%E5%BE%AE%E4%BF%A1%E6%88%AA%E5%9B%BE_20190808140430.png](https://oss.iacblog.com/github/%E5%BE%AE%E4%BF%A1%E6%88%AA%E5%9B%BE_20190808140430.png)
![https://oss.iacblog.com/github/%E5%BE%AE%E4%BF%A1%E6%88%AA%E5%9B%BE_20190808140446.png](https://oss.iacblog.com/github/%E5%BE%AE%E4%BF%A1%E6%88%AA%E5%9B%BE_20190808140446.png)
![https://oss.iacblog.com/github/%E5%BE%AE%E4%BF%A1%E6%88%AA%E5%9B%BE_20190808141458.png](https://oss.iacblog.com/github/%E5%BE%AE%E4%BF%A1%E6%88%AA%E5%9B%BE_20190808141458.png)