### PR TITLE
ats model support json

### DIFF
--- a/src/database/src/Commands/Ast/ModelUpdateVisitor.php
+++ b/src/database/src/Commands/Ast/ModelUpdateVisitor.php
@@ -107,6 +107,8 @@ class ModelUpdateVisitor extends NodeVisitorAbstract
             case 'bool':
             case 'boolean':
                 return 'boolean';
+            case 'json':
+                return 'json';
             default:
                 return null;
         }


### PR DESCRIPTION

The json type is enhanced when the model is automatically generated. No need for manual json_encode or json_decode

before
~~~php
 * @property string $config
    protected $casts = ['created_at' => 'datetime', 'id' => 'integer', 'updated_at' => 'datetime'];
~~~

after
~~~php
 * @property array $config
    protected $casts = ['config' => 'json', 'created_at' => 'datetime', 'id' => 'integer', 'updated_at' => 'datetime'];
~~~