### PR TITLE
add getClientIps() && getClientIp()

### DIFF
--- a/src/http-server/src/Contract/RequestInterface.php
+++ b/src/http-server/src/Contract/RequestInterface.php
@@ -166,4 +166,18 @@ interface RequestInterface extends ServerRequestInterface
      * Determine if the uploaded data contains a file.
      */
     public function hasFile(string $key): bool;
+
+    /**
+     * Get the client IP addresses.
+     *
+     * @return array
+     */
+    public function getClientIps(): array;
+
+    /**
+     * Get the client IP address.
+     *
+     * @return string
+     */
+    public function getClientIp(): string;
 }

--- a/src/http-server/src/Request.php
+++ b/src/http-server/src/Request.php
@@ -610,4 +610,33 @@ class Request implements RequestInterface
     {
         return Context::get(ServerRequestInterface::class);
     }
+
+    /**
+     * Get the client IP addresses.
+     *
+     * @return array
+     */
+    public function getClientIps(): array
+    {
+        $result = $ips = [];
+        $xff = $this->header("x-forwarded-for",null);
+        if ($xff){
+            $ips = explode(",",$xff);
+        }
+        $ips[] = $this->server("remote_addr");
+        foreach ($ips as &$ip) {
+            $result[] = trim($ip);
+        }
+        return $ips;
+    }
+
+    /**
+     * Get the client IP addresses.
+     *
+     * @return string
+     */
+    public function getClientIp(): string
+    {
+        return $this->getClientIps()[0] ?? "0.0.0.0";
+    }
 }


### PR DESCRIPTION
支持Request中 使用getClientIps()以及getClientIp()获得ip

但是这东西存在个问题，大家一般都会在hyperf前面加层7层的proxy(nginx/haproxy/slb)等等。这个时候其实7层传递给后端的ip是通过Header的方式。目前只兼容了``x-forwarded-for``的情况,有些CDN/SLB提供商使用的并不是这个，所以感觉存在兼容性的问题。由于这个是通过Header，所以会存在伪造IP的问题。不知道大佬们对这个有什么建议？