### PR TITLE
Fixed the `ExceptionHandler` that user defined does not works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [#361](https://github.com/hyperf-cloud/hyperf/pull/361) Fixed command `db:model` not work in mysql 8.
 - [#369](https://github.com/hyperf-cloud/hyperf/pull/369) Fixed exception which instanceof serializable normalize and denormalize failed.
+- [#384](https://github.com/hyperf-cloud/hyperf/pull/384) Fixed `ExceptionHandler` user defined not work well. Because framework auto handle it.
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 ## Fixed
 
-- [#361](https://github.com/hyperf-cloud/hyperf/pull/361) Fixed command `db:model` not work in mysql 8.
+- [#361](https://github.com/hyperf-cloud/hyperf/pull/361) Fixed command `db:model` does not works in MySQL 8.
 - [#369](https://github.com/hyperf-cloud/hyperf/pull/369) Fixed exception which instanceof serializable normalize and denormalize failed.
-- [#384](https://github.com/hyperf-cloud/hyperf/pull/384) Fixed `ExceptionHandler` user defined not work well. Because framework auto handle it.
+- [#384](https://github.com/hyperf-cloud/hyperf/pull/384) Fixed the `ExceptionHandler` that user defined does not works, because the framework has handled the exception automatically.
 
 ## Changed
 

--- a/src/http-server/src/Server.php
+++ b/src/http-server/src/Server.php
@@ -85,9 +85,7 @@ class Server implements OnRequestInterface, MiddlewareInitializerInterface
 
         $config = $this->container->get(ConfigInterface::class);
         $this->middlewares = $config->get('middlewares.' . $serverName, []);
-        $this->exceptionHandlers = $config->get('exceptions.handler.' . $serverName, [
-            HttpExceptionHandler::class,
-        ]);
+        $this->exceptionHandlers = $config->get('exceptions.handler.' . $serverName, $this->getDefaultExceptionHandler());
     }
 
     public function onRequest(SwooleRequest $request, SwooleResponse $response): void
@@ -123,6 +121,13 @@ class Server implements OnRequestInterface, MiddlewareInitializerInterface
     {
         $this->serverName = $serverName;
         return $this;
+    }
+
+    protected function getDefaultExceptionHandler(): array
+    {
+        return [
+            HttpExceptionHandler::class,
+        ];
     }
 
     protected function createCoreMiddleware(): MiddlewareInterface

--- a/src/json-rpc/src/CoreMiddleware.php
+++ b/src/json-rpc/src/CoreMiddleware.php
@@ -48,8 +48,11 @@ class CoreMiddleware extends \Hyperf\RpcServer\CoreMiddleware
             $parameters = $this->parseParameters($controller, $action, $request->getParsedBody());
             try {
                 $response = $controllerInstance->{$action}(...$parameters);
-            } catch (\Exception $e) {
-                return $this->responseBuilder->buildErrorResponse($request, ResponseBuilder::SERVER_ERROR, $e);
+            } catch (\Exception $exception) {
+                $response = $this->responseBuilder->buildErrorResponse($request, ResponseBuilder::SERVER_ERROR, $exception);
+                $this->responseBuilder->saveResponse($response);
+
+                throw $exception;
             }
         }
         return $response;

--- a/src/json-rpc/src/CoreMiddleware.php
+++ b/src/json-rpc/src/CoreMiddleware.php
@@ -50,7 +50,7 @@ class CoreMiddleware extends \Hyperf\RpcServer\CoreMiddleware
                 $response = $controllerInstance->{$action}(...$parameters);
             } catch (\Exception $exception) {
                 $response = $this->responseBuilder->buildErrorResponse($request, ResponseBuilder::SERVER_ERROR, $exception);
-                $this->responseBuilder->saveResponse($response);
+                $this->responseBuilder->persistToContext($response);
 
                 throw $exception;
             }

--- a/src/json-rpc/src/Exception/Handler/HttpExceptionHandler.php
+++ b/src/json-rpc/src/Exception/Handler/HttpExceptionHandler.php
@@ -21,8 +21,14 @@ use Throwable;
 
 class HttpExceptionHandler extends ExceptionHandler
 {
+    /**
+     * @var StdoutLoggerInterface
+     */
     protected $logger;
 
+    /**
+     * @var FormatterInterface
+     */
     protected $formatter;
 
     public function __construct(StdoutLoggerInterface $logger, FormatterInterface $formatter)

--- a/src/json-rpc/src/Exception/Handler/HttpExceptionHandler.php
+++ b/src/json-rpc/src/Exception/Handler/HttpExceptionHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf-cloud/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\JsonRpc\Exception\Handler;
+
+use Exception;
+use Hyperf\Contract\StdoutLoggerInterface;
+use Hyperf\ExceptionHandler\ExceptionHandler;
+use Hyperf\ExceptionHandler\Formatter\FormatterInterface;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+
+class HttpExceptionHandler extends ExceptionHandler
+{
+    protected $logger;
+
+    protected $formatter;
+
+    public function __construct(StdoutLoggerInterface $logger, FormatterInterface $formatter)
+    {
+        $this->logger = $logger;
+        $this->formatter = $formatter;
+    }
+
+    public function handle(Throwable $throwable, ResponseInterface $response)
+    {
+        $this->logger->warning($this->formatter->format($throwable));
+
+        $this->stopPropagation();
+
+        return $response;
+    }
+
+    public function isValid(Throwable $throwable): bool
+    {
+        return $throwable instanceof Exception;
+    }
+}

--- a/src/json-rpc/src/HttpServer.php
+++ b/src/json-rpc/src/HttpServer.php
@@ -15,6 +15,7 @@ namespace Hyperf\JsonRpc;
 use Hyperf\HttpMessage\Server\Request as Psr7Request;
 use Hyperf\HttpMessage\Server\Response as Psr7Response;
 use Hyperf\HttpServer\Server;
+use Hyperf\JsonRpc\Exception\Handler\HttpExceptionHandler;
 use Hyperf\Rpc\Protocol;
 use Hyperf\Rpc\ProtocolManager;
 use Hyperf\Utils\Context;
@@ -57,6 +58,13 @@ class HttpServer extends Server
             'dataFormatter' => $this->protocol->getDataFormatter(),
             'packer' => $this->packer,
         ]);
+    }
+
+    protected function getDefaultExceptionHandler(): array
+    {
+        return [
+            HttpExceptionHandler::class,
+        ];
     }
 
     protected function createCoreMiddleware(): MiddlewareInterface

--- a/src/json-rpc/src/ResponseBuilder.php
+++ b/src/json-rpc/src/ResponseBuilder.php
@@ -63,6 +63,11 @@ class ResponseBuilder
             ->withBody($body);
     }
 
+    public function saveResponse(ResponseInterface $response): ResponseInterface
+    {
+        return Context::set(ResponseInterface::class, $response);
+    }
+
     protected function formatResponse($response, ServerRequestInterface $request): string
     {
         $response = $this->dataFormatter->formatResponse([$request->getAttribute('request_id') ?? '', $response]);

--- a/src/json-rpc/src/ResponseBuilder.php
+++ b/src/json-rpc/src/ResponseBuilder.php
@@ -63,7 +63,7 @@ class ResponseBuilder
             ->withBody($body);
     }
 
-    public function saveResponse(ResponseInterface $response): ResponseInterface
+    public function persistToContext(ResponseInterface $response): ResponseInterface
     {
         return Context::set(ResponseInterface::class, $response);
     }

--- a/src/json-rpc/tests/AnyParamCoreMiddlewareTest.php
+++ b/src/json-rpc/tests/AnyParamCoreMiddlewareTest.php
@@ -88,7 +88,11 @@ class AnyParamCoreMiddlewareTest extends TestCase
             ->withParsedBody([3, 0]);
         Context::set(ResponseInterface::class, new Response());
 
-        $response = $middleware->process($request, $handler);
+        try {
+            $response = $middleware->process($request, $handler);
+        } catch (\Throwable $exception) {
+            $response = Context::get(ResponseInterface::class);
+        }
         $this->assertEquals(200, $response->getStatusCode());
         $ret = json_decode((string) $response->getBody(), true);
 


### PR DESCRIPTION
fix https://github.com/hyperf-cloud/hyperf/issues/375

Fixed the `ExceptionHandler` that user defined does not works, because the framework has handled the exception automatically.