### PR TITLE
Optimize vendor:publish command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ## Fixed 
 
 - [#466](https://github.com/hyperf-cloud/hyperf/pull/466) Fixed error when the number of data is not enough to paginate.
-- [#466](https://github.com/hyperf-cloud/hyperf/pull/470) Optimized `vendor:publish` command, if the destination folder exist, then will not repeatedly create the folder.
+- [#466](https://github.com/hyperf-cloud/hyperf/pull/470) Optimized `vendor:publish` command, if the destination folder exists, then will not repeatedly create the folder.
 
 # v1.0.12 - 2019-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## Fixed 
 
 - [#466](https://github.com/hyperf-cloud/hyperf/pull/466) Fixed error when the number of data is not enough to paginate.
+- [#466](https://github.com/hyperf-cloud/hyperf/pull/470) Optimized `vendor:publish` command, if the destination folder exist, then will not repeatedly create the folder.
 
 # v1.0.12 - 2019-08-21
 

--- a/src/devtool/src/VendorPublishCommand.php
+++ b/src/devtool/src/VendorPublishCommand.php
@@ -113,7 +113,9 @@ class VendorPublishCommand extends SymfonyCommand
                 continue;
             }
 
-            mkdir(dirname($destination), 0755, true);
+            if (! file_exists(dirname($destination))) {
+                mkdir(dirname($destination), 0755, true);
+            }
             copy($source, $destination);
 
             $this->output->writeln(sprintf('<fg=green>[%s] publish [%s] success.</>', $package, $id));


### PR DESCRIPTION
Optimized `vendor:publish` command, if the destination folder exists, then will not repeatedly create the folder.