### PR TITLE
Re-generate the fillable argument of Model when use refresh-fillable option, at the same time, the command will keep the fillable argument as default behaviours.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v1.0.14 - TBD
 
+## Added
+
+- [#482](https://github.com/hyperf-cloud/hyperf/pull/482) Don't auto rewrite fillable argument when using no-fillable option.
+
 ## Fixed
 
 - [#479](https://github.com/hyperf-cloud/hyperf/pull/479) Fixed typehint error when host of Elasticsearch client does not reached.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Changed
 
-- [#482](https://github.com/hyperf-cloud/hyperf/pull/482) Don't auto rewrite fillable argument unless using refresh-fillable option.
+- [#482](https://github.com/hyperf-cloud/hyperf/pull/482) Re-generate the `fillable` argument of Model when use `refresh-fillable` option, at the same time, the command will keep the `fillable` argument as default behaviours.
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v1.0.14 - TBD
 
-## Added
+## Changed
 
-- [#482](https://github.com/hyperf-cloud/hyperf/pull/482) Don't auto rewrite fillable argument when using no-fillable option.
+- [#482](https://github.com/hyperf-cloud/hyperf/pull/482) Don't auto rewrite fillable argument unless using refresh-fillable option.
 
 ## Fixed
 

--- a/src/database/src/Commands/Ast/ModelUpdateVisitor.php
+++ b/src/database/src/Commands/Ast/ModelUpdateVisitor.php
@@ -39,7 +39,7 @@ class ModelUpdateVisitor extends NodeVisitorAbstract
     {
         switch ($node) {
             case $node instanceof Node\Stmt\PropertyProperty:
-                if ($node->name == 'fillable' && ! $this->option->isNoFillable()) {
+                if ($node->name == 'fillable' && $this->option->isRefreshFillable()) {
                     $node = $this->rewriteFillable($node);
                 } elseif ($node->name == 'casts') {
                     $node = $this->rewriteCasts($node);

--- a/src/database/src/Commands/Ast/ModelUpdateVisitor.php
+++ b/src/database/src/Commands/Ast/ModelUpdateVisitor.php
@@ -12,24 +12,34 @@ declare(strict_types=1);
 
 namespace Hyperf\Database\Commands\Ast;
 
+use Hyperf\Database\Commands\ModelOption;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
 class ModelUpdateVisitor extends NodeVisitorAbstract
 {
+    /**
+     * @var array
+     */
     protected $columns = [];
 
-    public function __construct($columns = [])
+    /**
+     * @var ModelOption
+     */
+    protected $option;
+
+    public function __construct($columns = [], ModelOption $option)
     {
         $this->columns = $columns;
+        $this->option = $option;
     }
 
     public function leaveNode(Node $node)
     {
         switch ($node) {
             case $node instanceof Node\Stmt\PropertyProperty:
-                if ($node->name == 'fillable') {
+                if ($node->name == 'fillable' && ! $this->option->isNoFillable()) {
                     $node = $this->rewriteFillable($node);
                 } elseif ($node->name == 'casts') {
                     $node = $this->rewriteCasts($node);

--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -93,7 +93,8 @@ class ModelCommand extends Command
             ->setPrefix($this->getOption('prefix', 'prefix', $pool, ''))
             ->setInheritance($this->getOption('inheritance', 'commands.db:model.inheritance', $pool, 'Model'))
             ->setUses($this->getOption('uses', 'commands.db:model.uses', $pool, 'Hyperf\DbConnection\Model\Model'))
-            ->setForceCasts($this->getOption('force-casts', 'commands.db:model.force_casts', $pool, false));
+            ->setForceCasts($this->getOption('force-casts', 'commands.db:model.force_casts', $pool, false))
+            ->setNoFillable($this->getOption('no-fillable', 'commands.db:model.no_fillable', $pool, false));
 
         if ($table) {
             $this->createModel($table, $option);
@@ -112,6 +113,7 @@ class ModelCommand extends Command
         $this->addOption('prefix', 'P', InputOption::VALUE_OPTIONAL, 'What prefix that you want the Model set.');
         $this->addOption('inheritance', 'i', InputOption::VALUE_OPTIONAL, 'The inheritance that you want the Model extends.');
         $this->addOption('uses', 'U', InputOption::VALUE_OPTIONAL, 'The default class uses of the Model.');
+        $this->addOption('no-fillable', null, InputOption::VALUE_NONE, 'Whether generate fillable argement for model.');
     }
 
     protected function getSchemaBuilder(string $poolName): MySqlBuilder
@@ -158,7 +160,10 @@ class ModelCommand extends Command
 
         $stms = $this->astParser->parse(file_get_contents($path));
         $traverser = new NodeTraverser();
-        $visitor = make(ModelUpdateVisitor::class, ['columns' => $columns]);
+        $visitor = make(ModelUpdateVisitor::class, [
+            'columns' => $columns,
+            'option' => $option,
+        ]);
         $traverser->addVisitor($visitor);
         $stms = $traverser->traverse($stms);
         $code = $this->printer->prettyPrintFile($stms);
@@ -203,7 +208,7 @@ class ModelCommand extends Command
     protected function getOption(string $name, string $key, string $pool = 'default', $default = null)
     {
         $result = $this->input->getOption($name);
-        $nonInput = $name === 'force-casts' ? false : null;
+        $nonInput = in_array($name, ['force-casts', 'no-fillable']) ? false : null;
         if ($result === $nonInput) {
             $result = $this->config->get("databases.{$pool}.{$key}", $default);
         }

--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -94,7 +94,7 @@ class ModelCommand extends Command
             ->setInheritance($this->getOption('inheritance', 'commands.db:model.inheritance', $pool, 'Model'))
             ->setUses($this->getOption('uses', 'commands.db:model.uses', $pool, 'Hyperf\DbConnection\Model\Model'))
             ->setForceCasts($this->getOption('force-casts', 'commands.db:model.force_casts', $pool, false))
-            ->setNoFillable($this->getOption('no-fillable', 'commands.db:model.no_fillable', $pool, false));
+            ->setRefreshFillable($this->getOption('refresh-fillable', 'commands.db:model.refresh_fillable', $pool, false));
 
         if ($table) {
             $this->createModel($table, $option);
@@ -113,7 +113,7 @@ class ModelCommand extends Command
         $this->addOption('prefix', 'P', InputOption::VALUE_OPTIONAL, 'What prefix that you want the Model set.');
         $this->addOption('inheritance', 'i', InputOption::VALUE_OPTIONAL, 'The inheritance that you want the Model extends.');
         $this->addOption('uses', 'U', InputOption::VALUE_OPTIONAL, 'The default class uses of the Model.');
-        $this->addOption('no-fillable', null, InputOption::VALUE_NONE, 'Whether generate fillable argement for model.');
+        $this->addOption('refresh-fillable', null, InputOption::VALUE_NONE, 'Whether generate fillable argement for model.');
     }
 
     protected function getSchemaBuilder(string $poolName): MySqlBuilder
@@ -208,7 +208,7 @@ class ModelCommand extends Command
     protected function getOption(string $name, string $key, string $pool = 'default', $default = null)
     {
         $result = $this->input->getOption($name);
-        $nonInput = in_array($name, ['force-casts', 'no-fillable']) ? false : null;
+        $nonInput = in_array($name, ['force-casts', 'refresh-fillable']) ? false : null;
         if ($result === $nonInput) {
             $result = $this->config->get("databases.{$pool}.{$key}", $default);
         }

--- a/src/database/src/Commands/ModelOption.php
+++ b/src/database/src/Commands/ModelOption.php
@@ -104,36 +104,22 @@ class ModelOption
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getUses(): string
     {
         return $this->uses;
     }
 
-    /**
-     * @param string $uses
-     * @return ModelOption
-     */
     public function setUses(string $uses): ModelOption
     {
         $this->uses = $uses;
         return $this;
     }
 
-    /**
-     * @return bool
-     */
     public function isRefreshFillable(): bool
     {
         return $this->refreshFillable;
     }
 
-    /**
-     * @param bool $refreshFillable
-     * @return ModelOption
-     */
     public function setRefreshFillable(bool $refreshFillable): ModelOption
     {
         $this->refreshFillable = $refreshFillable;

--- a/src/database/src/Commands/ModelOption.php
+++ b/src/database/src/Commands/ModelOption.php
@@ -44,6 +44,11 @@ class ModelOption
      */
     protected $uses;
 
+    /**
+     * @var bool
+     */
+    protected $noFillable;
+
     public function getPool(): string
     {
         return $this->pool;
@@ -114,6 +119,24 @@ class ModelOption
     public function setUses(string $uses): ModelOption
     {
         $this->uses = $uses;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isNoFillable(): bool
+    {
+        return $this->noFillable;
+    }
+
+    /**
+     * @param bool $noFillable
+     * @return ModelOption
+     */
+    public function setNoFillable(bool $noFillable): ModelOption
+    {
+        $this->noFillable = $noFillable;
         return $this;
     }
 }

--- a/src/database/src/Commands/ModelOption.php
+++ b/src/database/src/Commands/ModelOption.php
@@ -47,7 +47,7 @@ class ModelOption
     /**
      * @var bool
      */
-    protected $noFillable;
+    protected $refreshFillable;
 
     public function getPool(): string
     {
@@ -125,18 +125,18 @@ class ModelOption
     /**
      * @return bool
      */
-    public function isNoFillable(): bool
+    public function isRefreshFillable(): bool
     {
-        return $this->noFillable;
+        return $this->refreshFillable;
     }
 
     /**
-     * @param bool $noFillable
+     * @param bool $refreshFillable
      * @return ModelOption
      */
-    public function setNoFillable(bool $noFillable): ModelOption
+    public function setRefreshFillable(bool $refreshFillable): ModelOption
     {
-        $this->noFillable = $noFillable;
+        $this->refreshFillable = $refreshFillable;
         return $this;
     }
 }


### PR DESCRIPTION
fix https://github.com/hyperf-cloud/hyperf/issues/475