### PR TITLE
When the path argument of Mapping annotation is an empty string, then the path is equal to prefix of Controller annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Changed
 
 - [#482](https://github.com/hyperf-cloud/hyperf/pull/482) Re-generate the `fillable` argument of Model when use `refresh-fillable` option, at the same time, the command will keep the `fillable` argument as default behaviours.
+- [#501](https://github.com/hyperf-cloud/hyperf/pull/501) When the path argument of Mapping annotation is an empty string, then the path is equal to prefix of Controller annotation.
 
 ## Fixed
 

--- a/src/http-server/src/Router/DispatcherFactory.php
+++ b/src/http-server/src/Router/DispatcherFactory.php
@@ -180,7 +180,9 @@ class DispatcherFactory
                     }
                     $path = $mapping->path;
 
-                    if ($path[0] !== '/') {
+                    if ($path === '') {
+                        $path = $prefix;
+                    } elseif ($path[0] !== '/') {
                         $path = $prefix . '/' . $path;
                     }
                     $router->addRoute($mapping->methods, $path, [


### PR DESCRIPTION
fix #488 