### PR TITLE
ensure returns -1 when running in non-coroutine context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Fixed
 
 - [#479](https://github.com/hyperf-cloud/hyperf/pull/479) Fixed typehint error when host of Elasticsearch client does not reached.
+- [#508](https://github.com/hyperf-cloud/hyperf/pull/508) ensure returns -1 when running in non-coroutine context
 
 # v1.0.13 - 2019-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@
 ## Fixed
 
 - [#479](https://github.com/hyperf-cloud/hyperf/pull/479) Fixed typehint error when host of Elasticsearch client does not reached.
-- [#508](https://github.com/hyperf-cloud/hyperf/pull/508) ensure returns -1 when running in non-coroutine context
+- [#508](https://github.com/hyperf-cloud/hyperf/pull/508) Fixed typehint error for `Coroutine::parentId` when running in non-coroutine environment.
 
 # v1.0.13 - 2019-08-28
 
 ## Added
 
-- [#449](https://github.com/hyperf-cloud/hyperf/pull/428) Added an independent component [hyperf/translation](https://github.com/hyperf-cloud/translation), forked by illuminate/translation.
+- [#428](https://github.com/hyperf-cloud/hyperf/pull/428) Added an independent component [hyperf/translation](https://github.com/hyperf-cloud/translation), forked by illuminate/translation.
 - [#449](https://github.com/hyperf-cloud/hyperf/pull/449) Added standard error code for grpc-server.
 - [#450](https://github.com/hyperf-cloud/hyperf/pull/450) Added comments of static methods for `Hyperf\Database\Schema\Schema`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## Fixed
 
 - [#479](https://github.com/hyperf-cloud/hyperf/pull/479) Fixed typehint error when host of Elasticsearch client does not reached.
-- [#508](https://github.com/hyperf-cloud/hyperf/pull/508) Fixed typehint error for `Coroutine::parentId` when running in non-coroutine environment.
+- [#508](https://github.com/hyperf-cloud/hyperf/pull/508) Fixed return type error of `Hyperf\Utils\Coroutine::parentId()` when running in non-coroutine environment.
 
 # v1.0.13 - 2019-08-28
 

--- a/src/utils/src/Coroutine.php
+++ b/src/utils/src/Coroutine.php
@@ -43,10 +43,17 @@ class Coroutine
     /**
      * Returns the parent coroutine ID.
      * Returns -1 when running in non-coroutine context.
+     *
+     * @see https://github.com/swoole/swoole-src/pull/2669/files#diff-3bdf726b0ac53be7e274b60d59e6ec80R940
      */
     public static function parentId(): int
     {
-        return SwooleCoroutine::getPcid();
+        $result = SwooleCoroutine::getPcid();
+        if ($result === false) {
+            return -1;
+        }
+
+        return $result;
     }
 
     /**

--- a/src/utils/src/Coroutine.php
+++ b/src/utils/src/Coroutine.php
@@ -48,12 +48,12 @@ class Coroutine
      */
     public static function parentId(): int
     {
-        $result = SwooleCoroutine::getPcid();
-        if ($result === false) {
+        $cid = SwooleCoroutine::getPcid();
+        if ($cid === false) {
             return -1;
         }
 
-        return $result;
+        return $cid;
     }
 
     /**


### PR DESCRIPTION
修复 `Coroutine::parentId` 因在非协程环境下 `SwooleCoroutine::getPcid()` 返回 false 导致的类型不匹配问题。 