### PR TITLE
If swoole method return false, transfer the result to null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#482](https://github.com/hyperf-cloud/hyperf/pull/482) Re-generate the `fillable` argument of Model when use `refresh-fillable` option, at the same time, the command will keep the `fillable` argument as default behaviours.
 - [#501](https://github.com/hyperf-cloud/hyperf/pull/501) When the path argument of Mapping annotation is an empty string, then the path is equal to prefix of Controller annotation.
 - [#513](https://github.com/hyperf-cloud/hyperf/pull/513) Rewrite process name with `app_name`.
+- [#526](https://github.com/hyperf-cloud/hyperf/pull/526) When execute `Hyperf\Utils\Coroutine::parentId()` static method in non-coroutine context will return null.
 
 ## Fixed
 

--- a/src/utils/src/Coroutine.php
+++ b/src/utils/src/Coroutine.php
@@ -42,15 +42,16 @@ class Coroutine
 
     /**
      * Returns the parent coroutine ID.
-     * Returns -1 when running in non-coroutine context.
+     * Returns -1 when running in the top level coroutine.
+     * Returns null when running in non-coroutine context.
      *
      * @see https://github.com/swoole/swoole-src/pull/2669/files#diff-3bdf726b0ac53be7e274b60d59e6ec80R940
      */
-    public static function parentId(): int
+    public static function parentId(): ?int
     {
         $cid = SwooleCoroutine::getPcid();
         if ($cid === false) {
-            return -1;
+            return null;
         }
 
         return $cid;


### PR DESCRIPTION
`Hyperf\Utils\Coroutine::parentId()`
Returns the parent coroutine ID.
Returns -1 when running in the top level coroutine.
Returns null when running in non-coroutine context.