### PR TITLE
修正文档错别字和跳转链接

### DIFF
--- a/doc/en/awesome-components.md
+++ b/doc/en/awesome-components.md
@@ -70,7 +70,7 @@ We have provided you with a [Hyperf component development guide](en/component-gu
 - [hyperf/json-rpc](https://github.com/hyperf-cloud/json-rpc) JSON-RPC protocol component provided by Hyperf officially
 - [hyperf/rate-limit](https://github.com/hyperf-cloud/rate-limit) Token bucket algorithm-based rate limiter component provided by Hyperf officially
 - [hyperf/load-balancer](https://github.com/hyperf-cloud/load-balancer) Load balancer component provided by Hyperf officially
-- [hyperf/service-gevernance](https://github.com/hyperf-cloud/service-gevernance) Service governance component provided by Hyperf officially
+- [hyperf/service-governance](https://github.com/hyperf-cloud/service-governance) Service governance component provided by Hyperf officially
 - [hyperf/tracer](https://github.com/hyperf-cloud/tracer) OpenTracing component provided by Hyperf officially
 - [hyperf/circuit-breaker](https://github.com/hyperf-cloud/circuit-breaker) service circuit breaker component provided by Hyperf officially
 

--- a/doc/zh/awesome-components.md
+++ b/doc/zh/awesome-components.md
@@ -77,7 +77,7 @@
 
 - [hyperf/rate-limit](https://github.com/hyperf-cloud/rate-limit) Hyperf 官方提供的基于令牌桶算法的限流组件
 - [hyperf/load-balancer](https://github.com/hyperf-cloud/load-balancer) Hyperf 官方提供的负载均衡组件
-- [hyperf/service-gevernance](https://github.com/hyperf-cloud/service-gevernance) Hyperf 官方提供的服务治理组件
+- [hyperf/service-governance](https://github.com/hyperf-cloud/service-governance) Hyperf 官方提供的服务治理组件
 - [hyperf/tracer](https://github.com/hyperf-cloud/tracer) Hyperf 官方提供的 OpenTracing 分布式调用链追踪组件
 - [hyperf/circuit-breaker](https://github.com/hyperf-cloud/circuit-breaker) Hyperf 官方提供的服务熔断组件
 


### PR DESCRIPTION
现文档`协程组件库`一栏

- 服务治理 `hyperf/service-gevernance` 名称编写错误，以及跳转链接404
- 根据搜索发现实际名称为 `hyperf/service-governance` ，现予修正