### PR TITLE
Fixed the next request will be effected after using stopPropagation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - [#565](https://github.com/hyperf-cloud/hyperf/pull/565) Added options config for redis.
 
+## Fixed 
+
+- [#571](https://github.com/hyperf-cloud/hyperf/pull/571) Fixed the next request will be effected after using stopPropagation.
+
 # v1.0.15 - 2019-09-11
 
 ## Fixed

--- a/composer.json
+++ b/composer.json
@@ -187,6 +187,7 @@
             "HyperfTest\\Elasticsearch\\": "src/elasticsearch/tests/",
             "HyperfTest\\Etcd\\": "src/etcd/tests/",
             "HyperfTest\\Event\\": "src/event/tests/",
+            "HyperfTest\\ExceptionHandler\\": "src/exception-handler/tests/",
             "HyperfTest\\GrpcClient\\": "src/grpc-client/tests/",
             "HyperfTest\\GrpcServer\\": "src/grpc-server/tests/",
             "HyperfTest\\Guzzle\\": "src/guzzle/tests/",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,6 +22,7 @@
             <directory suffix="Test.php">./src/dispatcher/tests</directory>
             <directory suffix="Test.php">./src/elasticsearch/tests</directory>
             <directory suffix="Test.php">./src/event/tests</directory>
+            <directory suffix="Test.php">./src/exception-handler/tests</directory>
             <directory suffix="Test.php">./src/grpc-client/tests</directory>
             <directory suffix="Test.php">./src/grpc-server/tests</directory>
             <directory suffix="Test.php">./src/guzzle/tests</directory>

--- a/src/exception-handler/.gitattributes
+++ b/src/exception-handler/.gitattributes
@@ -1,0 +1,1 @@
+/tests export-ignore

--- a/src/exception-handler/composer.json
+++ b/src/exception-handler/composer.json
@@ -15,6 +15,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "HyperfTest\\ExceptionHandler\\": "tests/"
         }
     },
     "require": {

--- a/src/exception-handler/src/ExceptionHandler.php
+++ b/src/exception-handler/src/ExceptionHandler.php
@@ -18,13 +18,6 @@ use Throwable;
 abstract class ExceptionHandler
 {
     /**
-     * Determine if the exception should propagate to next handler.
-     *
-     * @var bool
-     */
-    protected $propagationStopped = false;
-
-    /**
      * Handle the exception, and return the specified result.
      */
     abstract public function handle(Throwable $throwable, ResponseInterface $response);
@@ -43,8 +36,8 @@ abstract class ExceptionHandler
      */
     public function stopPropagation(): bool
     {
-        $this->propagationStopped = true;
-        return $this->propagationStopped;
+        Propagation::instance()->setPropagationStopped(true);
+        return true;
     }
 
     /**
@@ -54,6 +47,6 @@ abstract class ExceptionHandler
      */
     public function isPropagationStopped(): bool
     {
-        return $this->propagationStopped;
+        return Propagation::instance()->isPropagationStopped();
     }
 }

--- a/src/exception-handler/src/Propagation.php
+++ b/src/exception-handler/src/Propagation.php
@@ -1,10 +1,38 @@
 <?php
 
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf-cloud/hyperf/blob/master/LICENSE
+ */
 
 namespace Hyperf\ExceptionHandler;
 
+use Hyperf\Utils\Traits\StaticInstance;
 
 class Propagation
 {
+    use StaticInstance;
 
+    /**
+     * Determine if the exception should propagate to next handler.
+     *
+     * @var bool
+     */
+    protected $propagationStopped = false;
+
+    public function isPropagationStopped(): bool
+    {
+        return $this->propagationStopped;
+    }
+
+    public function setPropagationStopped(bool $propagationStopped): Propagation
+    {
+        $this->propagationStopped = $propagationStopped;
+        return $this;
+    }
 }

--- a/src/exception-handler/src/Propagation.php
+++ b/src/exception-handler/src/Propagation.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Hyperf\ExceptionHandler;
+
+
+class Propagation
+{
+
+}

--- a/src/exception-handler/tests/ExceptionHandlerTest.php
+++ b/src/exception-handler/tests/ExceptionHandlerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf-cloud/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\ExceptionHandler;
+
+use Hyperf\ExceptionHandler\ExceptionHandlerDispatcher;
+use Hyperf\HttpMessage\Base\Response;
+use Hyperf\Utils\Context;
+use HyperfTest\ExceptionHandler\Stub\BarExceptionHandler;
+use HyperfTest\ExceptionHandler\Stub\FooExceptionHandler;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class ExceptionHandlerTest extends TestCase
+{
+    protected function tearDown()
+    {
+        Mockery::close();
+
+        Context::set('test.exception-handler.latest-handler', null);
+    }
+
+    public function testStopPropagation()
+    {
+        $handlers = [
+            BarExceptionHandler::class,
+            FooExceptionHandler::class,
+        ];
+
+        $container = $this->getContainer();
+
+        parallel([function () use ($container, $handlers) {
+            $exception = new \Exception('xxx', 500);
+
+            Context::set(ResponseInterface::class, new Response());
+
+            $dispatcher = new ExceptionHandlerDispatcher($container);
+            $dispatcher->dispatch($exception, $handlers);
+
+            $this->assertSame(FooExceptionHandler::class, Context::get('test.exception-handler.latest-handler'));
+        }]);
+
+        parallel([function () use ($container, $handlers) {
+            $exception = new \Exception('xxx', 0);
+
+            Context::set(ResponseInterface::class, new Response());
+
+            $dispatcher = new ExceptionHandlerDispatcher($container);
+            $dispatcher->dispatch($exception, $handlers);
+
+            $this->assertSame(BarExceptionHandler::class, Context::get('test.exception-handler.latest-handler'));
+        }]);
+
+        parallel([function () use ($container, $handlers) {
+            $exception = new \Exception('xxx', 500);
+
+            Context::set(ResponseInterface::class, new Response());
+
+            $dispatcher = new ExceptionHandlerDispatcher($container);
+            $dispatcher->dispatch($exception, $handlers);
+
+            $this->assertSame(FooExceptionHandler::class, Context::get('test.exception-handler.latest-handler'));
+        }]);
+    }
+
+    protected function getContainer()
+    {
+        $container = Mockery::mock(ContainerInterface::class);
+        $container->shouldReceive('has')->andReturn(true);
+        $container->shouldReceive('get')->with(BarExceptionHandler::class)->andReturn(new BarExceptionHandler());
+        $container->shouldReceive('get')->with(FooExceptionHandler::class)->andReturn(new FooExceptionHandler());
+
+        return $container;
+    }
+}

--- a/src/exception-handler/tests/Stub/BarExceptionHandler.php
+++ b/src/exception-handler/tests/Stub/BarExceptionHandler.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf-cloud/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\ExceptionHandler\Stub;
+
+use Hyperf\ExceptionHandler\ExceptionHandler;
+use Hyperf\Utils\Context;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+
+class BarExceptionHandler extends ExceptionHandler
+{
+    public function handle(Throwable $throwable, ResponseInterface $response)
+    {
+        Context::set('test.exception-handler.latest-handler', static::class);
+
+        if ($throwable->getCode() === 0) {
+            $this->stopPropagation();
+        }
+
+        return $response;
+    }
+
+    public function isValid(Throwable $throwable): bool
+    {
+        return true;
+    }
+}

--- a/src/exception-handler/tests/Stub/FooExceptionHandler.php
+++ b/src/exception-handler/tests/Stub/FooExceptionHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf-cloud/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\ExceptionHandler\Stub;
+
+use Hyperf\ExceptionHandler\ExceptionHandler;
+use Hyperf\Utils\Context;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+
+class FooExceptionHandler extends ExceptionHandler
+{
+    public function handle(Throwable $throwable, ResponseInterface $response)
+    {
+        Context::set('test.exception-handler.latest-handler', static::class);
+        return $response;
+    }
+
+    public function isValid(Throwable $throwable): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
因为 handler 是从 di 里取出来的，所以当修改了本身的 handler 属性后，导致 下个请求也会拿到一个修改后的 handler。

除非 handler 的获取那里改成 `make`

本PR是将stopPropagation 存到 Context 里处理的