### PR TITLE
修复分页currentPage失效

### DIFF
--- a/src/paginator/src/Paginator.php
+++ b/src/paginator/src/Paginator.php
@@ -147,6 +147,6 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
 
         $this->hasMore = $this->items->count() > $this->perPage;
 
-        $this->items = $this->items->slice(0, $this->perPage);
+        $this->items = $this->items->slice(($this->currentPage - 1) * $this->perPage, $this->perPage);
     }
 }


### PR DESCRIPTION
之前slice 参数为0 导致设置currentPage的时候一直都是第一页数据