### PR TITLE
Changed the structure of config provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,29 @@ return ApplicationContext::setContainer($container);
 
 - [#486](https://github.com/hyperf-cloud/hyperf/pull/486) Changed `getParsedBody` of Request is available to return JSON formatted data normally.
 - [#523](https://github.com/hyperf-cloud/hyperf/pull/523) The command `db:model` will generate the singular class name of an plural table as default.
+- [#614](https://github.com/hyperf-cloud/hyperf/pull/614) Changed the structure of config provider, also moved `config/dependencies.php` to `config/autoload/dependencies.php`, also you could place `dependencies` into config/config.php.
+
+Changed the structure of config provider:   
+Before:
+```php
+'scan' => [
+    'paths' => [
+        __DIR__,
+    ],
+    'collectors' => [],
+],
+```
+Now:
+```php
+'annotations' => [
+    'scan' => [
+        'paths' => [
+            __DIR__,
+        ],
+        'collectors' => [],
+    ],
+],
+```
 
 ## Deleted
 

--- a/src/amqp/src/ConfigProvider.php
+++ b/src/amqp/src/ConfigProvider.php
@@ -25,11 +25,11 @@ class ConfigProvider
                 Packer::class => JsonPacker::class,
                 Consumer::class => ConsumerFactory::class,
             ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
             'publish' => [

--- a/src/async-queue/src/ConfigProvider.php
+++ b/src/async-queue/src/ConfigProvider.php
@@ -17,13 +17,11 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
             'publish' => [

--- a/src/cache/src/ConfigProvider.php
+++ b/src/cache/src/ConfigProvider.php
@@ -22,15 +22,15 @@ class ConfigProvider
             'dependencies' => [
                 CacheInterface::class => Cache::class,
             ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
+                    'collectors' => [
+                        CacheListenerCollector::class,
+                    ]
                 ],
-                'collectors' => [
-                    CacheListenerCollector::class,
-                ]
             ],
             'publish' => [
                 [

--- a/src/circuit-breaker/src/ConfigProvider.php
+++ b/src/circuit-breaker/src/ConfigProvider.php
@@ -17,13 +17,11 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/config-aliyun-acm/src/ConfigProvider.php
+++ b/src/config-aliyun-acm/src/ConfigProvider.php
@@ -20,9 +20,11 @@ class ConfigProvider
             'dependencies' => [
                 ClientInterface::class => Client::class,
             ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
             'publish' => [

--- a/src/config-apollo/src/ConfigProvider.php
+++ b/src/config-apollo/src/ConfigProvider.php
@@ -20,9 +20,11 @@ class ConfigProvider
             'dependencies' => [
                 ClientInterface::class => ClientFactory::class,
             ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
             'publish' => [

--- a/src/config-etcd/src/ConfigProvider.php
+++ b/src/config-etcd/src/ConfigProvider.php
@@ -20,11 +20,12 @@ class ConfigProvider
             'dependencies' => [
                 ClientInterface::class => Client::class,
             ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
             'publish' => [

--- a/src/config/src/ConfigProvider.php
+++ b/src/config/src/ConfigProvider.php
@@ -22,9 +22,11 @@ class ConfigProvider
             'dependencies' => [
                 ConfigInterface::class => ConfigFactory::class,
             ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/config/src/ProviderConfig.php
+++ b/src/config/src/ProviderConfig.php
@@ -49,7 +49,7 @@ class ProviderConfig
     protected static function loadProviders(array $providers): array
     {
         $providerConfigs = [];
-        foreach ($providers ?? [] as $provider) {
+        foreach ($providers as $provider) {
             if (is_string($provider) && class_exists($provider) && method_exists($provider, '__invoke')) {
                 $providerConfigs[] = (new $provider())();
             }

--- a/src/config/tests/ProviderConfigTest.php
+++ b/src/config/tests/ProviderConfigTest.php
@@ -100,7 +100,7 @@ class ProviderConfigTest extends TestCase
 
         $dependencies = $res['dependencies'];
         $commands = $res['commands'];
-        $scanPaths = $res['scan']['paths'];
+        $scanPaths = $res['annotations']['scan']['paths'];
         $publish = $res['publish'];
         $listeners = $res['listeners'];
 

--- a/src/constants/src/ConfigProvider.php
+++ b/src/constants/src/ConfigProvider.php
@@ -17,12 +17,11 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
-            'scan' => [
-                'paths' => [],
-                'collectors' => [
-                    ConstantsCollector::class,
+            'annotations' => [
+                'scan' => [
+                    'collectors' => [
+                        ConstantsCollector::class,
+                    ],
                 ],
             ],
         ];

--- a/src/consul/src/ConfigProvider.php
+++ b/src/consul/src/ConfigProvider.php
@@ -17,12 +17,6 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
-            'scan' => [
-                'paths' => [
-                ],
-            ],
             'publish' => [
                 [
                     'id' => 'config',

--- a/src/crontab/src/ConfigProvider.php
+++ b/src/crontab/src/ConfigProvider.php
@@ -29,9 +29,11 @@ class ConfigProvider
                 CrontabRegisterListener::class,
                 OnPipeMessageListener::class,
             ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/db-connection/src/ConfigProvider.php
+++ b/src/db-connection/src/ConfigProvider.php
@@ -50,9 +50,11 @@ class ConfigProvider
                 RollbackCommand::class,
                 StatusCommand::class,
             ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
             'publish' => [

--- a/src/devtool/src/ConfigProvider.php
+++ b/src/devtool/src/ConfigProvider.php
@@ -17,13 +17,11 @@ class ConfigProvider
     public function __invoke()
     {
         return [
-            'dependencies' => [
-            ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
             'publish' => [

--- a/src/di/src/ConfigProvider.php
+++ b/src/di/src/ConfigProvider.php
@@ -31,13 +31,15 @@ class ConfigProvider
             'listeners' => [
                 BootApplicationListener::class,
             ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
-                ],
-                'collectors' => [
-                    AnnotationCollector::class,
-                    AspectCollector::class,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
+                    'collectors' => [
+                        AnnotationCollector::class,
+                        AspectCollector::class,
+                    ],
                 ],
             ],
         ];

--- a/src/di/src/Definition/DefinitionSourceFactory.php
+++ b/src/di/src/Definition/DefinitionSourceFactory.php
@@ -48,8 +48,8 @@ class DefinitionSourceFactory
         }
 
         $serverDependencies = $configFromProviders['dependencies'] ?? [];
-        if (file_exists($configDir . '/dependencies.php')) {
-            $definitions = include $configDir . '/dependencies.php';
+        if (file_exists($configDir . '/autoload/dependencies.php')) {
+            $definitions = include $configDir . '/autoload/dependencies.php';
             $serverDependencies = array_replace($serverDependencies, $definitions['dependencies'] ?? []);
         }
 

--- a/src/dispatcher/src/ConfigProvider.php
+++ b/src/dispatcher/src/ConfigProvider.php
@@ -17,11 +17,11 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/etcd/src/ConfigProvider.php
+++ b/src/etcd/src/ConfigProvider.php
@@ -20,11 +20,11 @@ class ConfigProvider
             'dependencies' => [
                 KVInterface::class => KVFactory::class,
             ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
             'publish' => [

--- a/src/event/src/ConfigProvider.php
+++ b/src/event/src/ConfigProvider.php
@@ -24,9 +24,11 @@ class ConfigProvider
                 ListenerProviderInterface::class => ListenerProviderFactory::class,
                 EventDispatcherInterface::class => EventDispatcherFactory::class,
             ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/event/tests/ConfigProviderTest.php
+++ b/src/event/tests/ConfigProviderTest.php
@@ -32,9 +32,11 @@ class ConfigProviderTest extends TestCase
                 ListenerProviderInterface::class => ListenerProviderFactory::class,
                 EventDispatcherInterface::class => EventDispatcherFactory::class,
             ],
-            'scan' => [
-                'paths' => [
-                    str_replace('/tests', '/src', __DIR__),
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        str_replace('/tests', '/src', __DIR__),
+                    ],
                 ],
             ],
         ], (new ConfigProvider())());

--- a/src/exception-handler/src/ConfigProvider.php
+++ b/src/exception-handler/src/ConfigProvider.php
@@ -23,11 +23,11 @@ class ConfigProvider
             'dependencies' => [
                 FormatterInterface::class => DefaultFormatter::class,
             ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/framework/src/ConfigProvider.php
+++ b/src/framework/src/ConfigProvider.php
@@ -25,9 +25,11 @@ class ConfigProvider
                 ApplicationInterface::class => ApplicationFactory::class,
                 StdoutLoggerInterface::class => StdoutLogger::class,
             ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/graphql/src/ConfigProvider.php
+++ b/src/graphql/src/ConfigProvider.php
@@ -39,9 +39,11 @@ class ConfigProvider
                 AuthorizationServiceInterface::class => FailAuthorizationService::class,
                 NamingStrategyInterface::class => NamingStrategy::class,
             ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/grpc-client/src/ConfigProvider.php
+++ b/src/grpc-client/src/ConfigProvider.php
@@ -16,13 +16,6 @@ class ConfigProvider
 {
     public function __invoke(): array
     {
-        return [
-            'dependencies' => [
-            ],
-            'scan' => [
-                'paths' => [
-                ],
-            ],
-        ];
+        return [];
     }
 }

--- a/src/grpc-server/src/ConfigProvider.php
+++ b/src/grpc-server/src/ConfigProvider.php
@@ -17,11 +17,11 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/http-server/src/ConfigProvider.php
+++ b/src/http-server/src/ConfigProvider.php
@@ -26,11 +26,11 @@ class ConfigProvider
                 ServerRequestInterface::class => Request::class,
                 ResponseInterface::class => Response::class,
             ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/json-rpc/src/ConfigProvider.php
+++ b/src/json-rpc/src/ConfigProvider.php
@@ -24,8 +24,6 @@ class ConfigProvider
             'dependencies' => [
                 DataFormatter::class => DataFormatterFactory::class,
             ],
-            'commands' => [
-            ],
             'listeners' => [
                 RegisterProtocolListener::class,
                 value(function () {
@@ -35,9 +33,11 @@ class ConfigProvider
                     return null;
                 }),
             ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/load-balancer/src/ConfigProvider.php
+++ b/src/load-balancer/src/ConfigProvider.php
@@ -16,15 +16,6 @@ class ConfigProvider
 {
     public function __invoke(): array
     {
-        return [
-            'dependencies' => [
-            ],
-            'commands' => [
-            ],
-            'scan' => [
-            ],
-            'publish' => [
-            ],
-        ];
+        return [];
     }
 }

--- a/src/logger/src/ConfigProvider.php
+++ b/src/logger/src/ConfigProvider.php
@@ -17,13 +17,11 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
             'publish' => [

--- a/src/logger/tests/ConfigProviderTest.php
+++ b/src/logger/tests/ConfigProviderTest.php
@@ -26,10 +26,8 @@ class ConfigProviderTest extends TestCase
         $dir = str_replace('/tests', '/src', __DIR__);
 
         $this->assertSame([
-            'dependencies' => [
-            ],
-            'commands' => [
-            ],
+
+
             'scan' => [
                 'paths' => [
                     $dir,

--- a/src/logger/tests/ConfigProviderTest.php
+++ b/src/logger/tests/ConfigProviderTest.php
@@ -26,11 +26,11 @@ class ConfigProviderTest extends TestCase
         $dir = str_replace('/tests', '/src', __DIR__);
 
         $this->assertSame([
-
-
-            'scan' => [
-                'paths' => [
-                    $dir,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        $dir,
+                    ],
                 ],
             ],
             'publish' => [

--- a/src/memory/src/ConfigProvider.php
+++ b/src/memory/src/ConfigProvider.php
@@ -17,10 +17,11 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/model-cache/src/ConfigProvider.php
+++ b/src/model-cache/src/ConfigProvider.php
@@ -17,13 +17,11 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
             'publish' => [

--- a/src/model-listener/src/ConfigProvider.php
+++ b/src/model-listener/src/ConfigProvider.php
@@ -19,16 +19,14 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
-                ],
-                'collectors' => [
-                    ListenerCollector::class,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
+                    'collectors' => [
+                        ListenerCollector::class,
+                    ],
                 ],
             ],
         ];

--- a/src/paginator/src/ConfigProvider.php
+++ b/src/paginator/src/ConfigProvider.php
@@ -25,15 +25,10 @@ class ConfigProvider
                 PaginatorInterface::class => Paginator::class,
                 LengthAwarePaginatorInterface::class => LengthAwarePaginator::class,
             ],
-            'commands' => [
-            ],
             'listeners' => [
                 PageResolverListener::class,
             ],
-            'scan' => [
-                'paths' => [
-                ],
-            ],
+
         ];
     }
 }

--- a/src/pool/src/ConfigProvider.php
+++ b/src/pool/src/ConfigProvider.php
@@ -17,13 +17,11 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/process/src/ConfigProvider.php
+++ b/src/process/src/ConfigProvider.php
@@ -17,13 +17,11 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/rate-limit/src/ConfigProvider.php
+++ b/src/rate-limit/src/ConfigProvider.php
@@ -17,13 +17,11 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/redis/src/ConfigProvider.php
+++ b/src/redis/src/ConfigProvider.php
@@ -20,11 +20,11 @@ class ConfigProvider
             'dependencies' => [
                 \Redis::class => Redis::class,
             ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
             'publish' => [

--- a/src/rpc-client/src/ConfigProvider.php
+++ b/src/rpc-client/src/ConfigProvider.php
@@ -19,16 +19,14 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
-            'commands' => [
-            ],
             'listeners' => [
                 AddConsumerDefinitionListener::class,
             ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/rpc-server/src/ConfigProvider.php
+++ b/src/rpc-server/src/ConfigProvider.php
@@ -17,13 +17,11 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/rpc-server/src/RequestDispatcher.php
+++ b/src/rpc-server/src/RequestDispatcher.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Hyperf\RpcServer;
 
-use Hyperf\Dispatcher\AbstractDispatcher;
 use Hyperf\Dispatcher\HttpDispatcher;
 use Hyperf\Dispatcher\HttpRequestHandler;
 use Psr\Container\ContainerInterface;

--- a/src/server/src/ConfigProvider.php
+++ b/src/server/src/ConfigProvider.php
@@ -23,14 +23,14 @@ class ConfigProvider
             'dependencies' => [
                 SwooleServer::class => SwooleServerFactory::class,
             ],
-            'commands' => [
-            ],
             'listeners' => [
                 InitProcessTitleListener::class,
             ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
             'publish' => [

--- a/src/service-governance/src/ConfigProvider.php
+++ b/src/service-governance/src/ConfigProvider.php
@@ -23,11 +23,11 @@ class ConfigProvider
             'dependencies' => [
                 ConsulAgent::class => ConsulAgentFactory::class,
             ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/swagger/src/ConfigProvider.php
+++ b/src/swagger/src/ConfigProvider.php
@@ -19,14 +19,8 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
             'commands' => [
                 GenCommand::class,
-            ],
-            'scan' => [
-            ],
-            'publish' => [
             ],
         ];
     }

--- a/src/swoole-enterprise/src/ConfigProvider.php
+++ b/src/swoole-enterprise/src/ConfigProvider.php
@@ -17,13 +17,11 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/swoole-tracker/src/ConfigProvider.php
+++ b/src/swoole-tracker/src/ConfigProvider.php
@@ -16,15 +16,6 @@ class ConfigProvider
 {
     public function __invoke(): array
     {
-        return [
-            'dependencies' => [
-            ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                ],
-            ],
-        ];
+        return [];
     }
 }

--- a/src/task/src/ConfigProvider.php
+++ b/src/task/src/ConfigProvider.php
@@ -17,18 +17,16 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
-            'commands' => [
-            ],
             'listeners' => [
                 Listener\InitServerListener::class,
                 Listener\OnFinishListener::class,
                 Listener\OnTaskListener::class,
             ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/tracer/src/ConfigProvider.php
+++ b/src/tracer/src/ConfigProvider.php
@@ -25,11 +25,11 @@ class ConfigProvider
                 SwitchManager::class => SwitchManagerFactory::class,
                 Client::class => Client::class,
             ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
             'publish' => [

--- a/src/translation/src/ConfigProvider.php
+++ b/src/translation/src/ConfigProvider.php
@@ -24,9 +24,11 @@ class ConfigProvider
                 TranslatorLoaderInterface::class => FileLoaderFactory::class,
                 TranslatorInterface::class => TranslatorFactory::class,
             ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
             'publish' => [

--- a/src/view/src/ConfigProvider.php
+++ b/src/view/src/ConfigProvider.php
@@ -20,11 +20,11 @@ class ConfigProvider
             'dependencies' => [
                 RenderInterface::class => Render::class,
             ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
             'publish' => [

--- a/src/websocket-client/src/ConfigProvider.php
+++ b/src/websocket-client/src/ConfigProvider.php
@@ -17,13 +17,11 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
-            'commands' => [
-            ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];

--- a/src/websocket-server/src/ConfigProvider.php
+++ b/src/websocket-server/src/ConfigProvider.php
@@ -17,15 +17,15 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-            ],
             'listeners' => [
                 Listener\InitSenderListener::class,
                 Listener\OnPipeMessageListener::class,
             ],
-            'scan' => [
-                'paths' => [
-                    __DIR__,
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
1. Moved `config/dependencies.php` to `config/autoload/dependencies.php`
2. Changed the structure
```php
'scan' => [
    'paths' => [
        __DIR__,
    ],
    'collectors' => [],
],
```

to

```php
'annotations' => [
    'scan' => [
        'paths' => [
            __DIR__,
        ],
        'collectors' => [],
    ],
],
```