### PR TITLE
apollo clientIp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#597](https://github.com/hyperf-cloud/hyperf/pull/597) Added concurrent for async-queue.
 - [#599](https://github.com/hyperf-cloud/hyperf/pull/599) Allows set the retry seconds according to attempt times of async queue consumer.
 - [#619](https://github.com/hyperf-cloud/hyperf/pull/619) Added HandlrStackFactory of guzzle.
+- [#629](https://github.com/hyperf-cloud/hyperf/pull/629) Allows to modify the `clientIp`, `pullTimeout`, `intervalTimeout` of Apollo client via config file.
 
 ## Changed
 

--- a/src/config-apollo/src/ClientFactory.php
+++ b/src/config-apollo/src/ClientFactory.php
@@ -24,7 +24,8 @@ class ClientFactory
         $option = make(Option::class);
         $option->setServer($config->get('apollo.server', 'http://127.0.0.1:8080'))
             ->setAppid($config->get('apollo.appid', ''))
-            ->setCluster($config->get('apollo.cluster', ''));
+            ->setCluster($config->get('apollo.cluster', ''))
+            ->setClientIp(current(swoole_get_local_ip()));
         $namespaces = $config->get('apollo.namespaces', []);
         $callbacks = [];
         foreach ($namespaces as $namespace => $callable) {

--- a/src/config-apollo/src/ClientFactory.php
+++ b/src/config-apollo/src/ClientFactory.php
@@ -21,11 +21,14 @@ class ClientFactory
     public function __invoke(ContainerInterface $container)
     {
         $config = $container->get(ConfigInterface::class);
+        /** @var \Hyperf\ConfigApollo\Option $option */
         $option = make(Option::class);
         $option->setServer($config->get('apollo.server', 'http://127.0.0.1:8080'))
             ->setAppid($config->get('apollo.appid', ''))
             ->setCluster($config->get('apollo.cluster', ''))
-            ->setClientIp(current(swoole_get_local_ip()));
+            ->setClientIp($config->get('apollo.client_ip', current(swoole_get_local_ip())))
+            ->setPullTimeout($config->get('apollo.pull_timeout', 10))
+            ->setIntervalTimeout($config->get('apollo.interval_timeout', 60));
         $namespaces = $config->get('apollo.namespaces', []);
         $callbacks = [];
         foreach ($namespaces as $namespace => $callable) {


### PR DESCRIPTION
目前apollo配置后台监控的实例列表的ip全是127.0.0.1, 没法正确监控到集群环境下每个服务器是否正确拉取到更新后的配置，增加了…