### PR TITLE
perf: 优化hyperf启动耗时, 元数据分类缓存, 有效缩短扫描时间

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ Now:
 - [#612](https://github.com/hyperf-cloud/hyperf/pull/612) Deleted useless `$url` for RingPHP Handlers.
 - [#616](https://github.com/hyperf-cloud/hyperf/pull/616) [#618](https://github.com/hyperf-cloud/hyperf/pull/618) Deleted useless code of guzzle.
 
+## Optimized
+
+- [#644](https://github.com/hyperf-cloud/hyperf/pull/644) Optimized annotation scan process, seperate to two scan parts `app` and `vendor`, greatly decrease the elapsed time.
+
 ## Fixed
 
 - [#448](https://github.com/hyperf-cloud/hyperf/pull/448) Fixed TCP Server does not works when HTTP Server or WebSocket Server exists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ Now:
 
 ## Optimized
 
-- [#644](https://github.com/hyperf-cloud/hyperf/pull/644) Optimized annotation scan process, seperate to two scan parts `app` and `vendor`, greatly decrease the elapsed time.
+- [#644](https://github.com/hyperf-cloud/hyperf/pull/644) Optimized annotation scan process, separate to two scan parts `app` and `vendor`, greatly decrease the elapsed time.
 
 ## Fixed
 

--- a/src/di/src/Annotation/Scanner.php
+++ b/src/di/src/Annotation/Scanner.php
@@ -53,8 +53,7 @@ class Scanner
         array_walk($this->ignoreAnnotations, function ($value) {
             AnnotationReader::addGlobalIgnoredName($value);
         });
-        $reader = new AnnotationReader();
-        $classCollection = [];
+        $meta = [];
         foreach ($finder as $file) {
             try {
                 $stmts = $this->parser->parse($file->getContents());
@@ -62,12 +61,19 @@ class Scanner
                 if (! $className) {
                     continue;
                 }
-                AstCollector::set($className, $stmts);
-                $classCollection[] = $className;
+                $meta[$className] = $stmts;
             } catch (\RuntimeException $e) {
                 continue;
             }
         }
+        $this->collect(array_keys($meta));
+
+        return $meta;
+    }
+
+    public function collect($classCollection)
+    {
+        $reader = new AnnotationReader();
         // Because the annotation class should loaded before use it, so load file via $finder previous, and then parse annotation here.
         foreach ($classCollection as $className) {
             $reflectionClass = ReflectionManager::reflectClass($className);
@@ -106,8 +112,6 @@ class Scanner
                 }
             }
         }
-
-        return $classCollection;
     }
 
     /**

--- a/src/di/src/Annotation/Scanner.php
+++ b/src/di/src/Annotation/Scanner.php
@@ -15,7 +15,6 @@ namespace Hyperf\Di\Annotation;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Hyperf\Di\Aop\Ast;
-use Hyperf\Di\Aop\AstCollector;
 use Hyperf\Di\ReflectionManager;
 use Symfony\Component\Finder\Finder;
 

--- a/src/di/src/Command/InitProxyCommand.php
+++ b/src/di/src/Command/InitProxyCommand.php
@@ -96,7 +96,8 @@ class InitProxyCommand extends Command
             $this->clearRuntime($runtime);
         }
 
-        $classCollection = $this->scanner->scan($scanDirs);
+        $meta = $this->scanner->scan($scanDirs);
+        $classCollection = array_keys($meta);
 
         foreach ($classCollection as $item) {
             try {


### PR DESCRIPTION
由于常规开发中 vendor 下的代码一般不会被修改, 所以 vendor 下元数据缓存的利用率就会很高, 此处改动能有效降低 `php bin/hyperf.php start` 启动耗时
本机硬件配置: 
- MacBook Pro (13-inch, 2017, Two Thunderbolt 3 ports)
- CPU 2.3 GHz Intel Core i5
- 内存 8 GB 2133 MHz LPDDR3
原本扫描时间: app 大概在 1s 左右, vendor 大概在 5s 左右
优化后缩短在1s左右

