### PR TITLE
Update 1.1.md

### DIFF
--- a/doc/zh/upgrade/1.1.md
+++ b/doc/zh/upgrade/1.1.md
@@ -69,7 +69,7 @@ return ApplicationContext::setContainer($container);
 
 ## 调整 composer.json 的依赖
 
-由于要升级到 1.1 版本的组件，而原来 skeleton 项目默认情况下是依赖 1.1.x 版本的组件的，所以我们需要对依赖的约束条件进行一些调整，将原来所有 Hyperf 组件的依赖 `~1.0.0` 修改为 `~1.1.0`，修改完后需运行 `composer update` 来将依赖项升级到 1.1 版本。   
+由于要升级到 1.1 版本的组件，而原来 skeleton 项目默认情况下是依赖 1.0.x 版本的组件的，所以我们需要对依赖的约束条件进行一些调整，将原来所有 Hyperf 组件的依赖 `~1.0.0` 修改为 `~1.1.0`，修改完后需运行 `composer update` 来将依赖项升级到 1.1 版本。   
 
 必须将所有 Hyperf 依赖都升级到 1.1 版本才可用，因为 1.1 调整了组件适配的 ConfigProvider 机制。
 


### PR DESCRIPTION
原来 skeleton 项目默认情况下是依赖 1.1.x 版本的组件
修改为
原来 skeleton 项目默认情况下是依赖 1.0.x 版本的组件