### PR TITLE
Fixed bug in ValidationMiddleware::shouldHandle

### DIFF
--- a/src/validation/src/Middleware/ValidationMiddleware.php
+++ b/src/validation/src/Middleware/ValidationMiddleware.php
@@ -99,7 +99,7 @@ class ValidationMiddleware implements MiddlewareInterface
 
     protected function shouldHandle(Dispatched $dispatched): bool
     {
-        return $dispatched->status === Dispatcher::FOUND || ! $dispatched->handler->callback instanceof Closure;
+        return $dispatched->status === Dispatcher::FOUND && ! $dispatched->handler->callback instanceof Closure;
     }
 
     /**


### PR DESCRIPTION
修复：开启表单验证中间件后，访问不存在路由时报错

```
PHP Notice:  Trying to get property 'callback' of non-object in /vendor/hyperf/validation/src/Middleware/ValidationMiddleware.php on line 102
```