### PR TITLE
fix: 使用 gen:model 命令从数据库生成模型时模型表名错误

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#664](https://github.com/hyperf-cloud/hyperf/pull/664) Changed the default return value of FormRequest::authorize which generate via `gen:request` command.
 - [#665](https://github.com/hyperf-cloud/hyperf/pull/665) Fixed framework will generate proxy class of all classes that in app directory every time.
 - [#667](https://github.com/hyperf-cloud/hyperf/pull/667) Fixed trying to get property 'callback' of non-object in `Hyperf\Validation\Middleware\ValidationMiddleware`.
+- [#674](https://github.com/hyperf-cloud/hyperf/pull/674) Fixed the table of Model is not correct when using `gen:model`.
 
 # v1.1.0 - 2019-10-08
 

--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -157,7 +157,7 @@ class ModelCommand extends Command
                 @mkdir($dir, 0755, true);
             }
 
-            file_put_contents($path, $this->buildClass($class, $option));
+            file_put_contents($path, $this->buildClass($table, $class, $option));
         }
 
         $columns = $this->getColumns($class, $columns, $option->isForceCasts());
@@ -231,7 +231,7 @@ class ModelCommand extends Command
     /**
      * Build the class with the given name.
      */
-    protected function buildClass(string $name, ModelOption $option): string
+    protected function buildClass(string $table, string $name, ModelOption $option): string
     {
         $stub = file_get_contents(__DIR__ . '/stubs/Model.stub');
 
@@ -239,7 +239,8 @@ class ModelCommand extends Command
             ->replaceInheritance($stub, $option->getInheritance())
             ->replaceConnection($stub, $option->getPool())
             ->replaceUses($stub, $option->getUses())
-            ->replaceClass($stub, $name);
+            ->replaceClass($stub, $name)
+            ->replaceTable($stub, $table);
     }
 
     /**
@@ -301,13 +302,21 @@ class ModelCommand extends Command
     /**
      * Replace the class name for the given stub.
      */
-    protected function replaceClass(string $stub, string $name): string
+    protected function replaceClass(string &$stub, string $name): self
     {
         $class = str_replace($this->getNamespace($name) . '\\', '', $name);
 
         $stub = str_replace('%CLASS%', $class, $stub);
 
-        return str_replace('%TABLE%', Str::snake($class), $stub);
+        return $this;
+    }
+
+    /**
+     * Replace the table name for the given stub.
+     */
+    protected function replaceTable(string $stub, string $table): string
+    {
+        return str_replace('%TABLE%', $table, $stub);
     }
 
     /**

--- a/src/validation/src/Middleware/ValidationMiddleware.php
+++ b/src/validation/src/Middleware/ValidationMiddleware.php
@@ -99,7 +99,7 @@ class ValidationMiddleware implements MiddlewareInterface
 
     protected function shouldHandle(Dispatched $dispatched): bool
     {
-        return $dispatched->status === Dispatcher::FOUND || ! $dispatched->handler->callback instanceof Closure;
+        return $dispatched->status === Dispatcher::FOUND && ! $dispatched->handler->callback instanceof Closure;
     }
 
     /**


### PR DESCRIPTION
https://github.com/hyperf-cloud/hyperf/blob/master/src/database/src/Commands/ModelCommand.php#L150

表名转类名时，先将表名转为单数，再转成 `studly caps case`

https://github.com/hyperf-cloud/hyperf/blob/master/src/database/src/Commands/ModelCommand.php#L310

此处仅将类名转换成 `snake case` ，并没有考虑表名是否复数的问题