### PR TITLE
Fixed the validator will be created repeatedly in `getValidatorInstance`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#700](https://github.com/hyperf-cloud/hyperf/pull/700) Fixed the `download` method of `Hyperf\HttpServer\Contract\ResponseInterface` does not works as expected.
 - [#701](https://github.com/hyperf-cloud/hyperf/pull/701) Fixed the custom process will not restart automatically when throw an uncaptured exception.
 - [#704](https://github.com/hyperf-cloud/hyperf/pull/704) Fixed bug that `Call to a member function getName() on null` in `Hyperf\Validation\Middleware\ValidationMiddleware` when the argument of action method does not define the argument type.
+- [#717](https://github.com/hyperf-cloud/hyperf/pull/717) Fixed the validator will be created repeatedly in `getValidatorInstance`.
 
 # v1.1.1 - 2019-10-08
 

--- a/src/utils/src/Context.php
+++ b/src/utils/src/Context.php
@@ -92,7 +92,7 @@ class Context
      * Retrieve the value and store it if not exists.
      * @param mixed $value
      */
-    public static function store(string $id, $value)
+    public static function getOrSet(string $id, $value)
     {
         if (! self::has($id)) {
             return self::set($id, value($value));

--- a/src/utils/src/Context.php
+++ b/src/utils/src/Context.php
@@ -88,6 +88,18 @@ class Context
         return $value;
     }
 
+    /**
+     * Retrieve the value and store it if not exists.
+     * @param mixed $value
+     */
+    public static function store(string $id, $value)
+    {
+        if (! self::has($id)) {
+            return self::set($id, value($value));
+        }
+        return self::get($id);
+    }
+
     public static function getContainer()
     {
         if (Coroutine::inCoroutine()) {

--- a/src/utils/tests/ContextTest.php
+++ b/src/utils/tests/ContextTest.php
@@ -32,17 +32,17 @@ class ContextTest extends TestCase
         $this->assertSame(2, Context::get('override.id'));
     }
 
-    public function testStore()
+    public function testGetOrSet()
     {
         Context::set('test.store.id', null);
-        $this->assertSame(1, Context::store('test.store.id', function () {
+        $this->assertSame(1, Context::getOrSet('test.store.id', function () {
             return 1;
         }));
-        $this->assertSame(1, Context::store('test.store.id', function () {
+        $this->assertSame(1, Context::getOrSet('test.store.id', function () {
             return 2;
         }));
 
         Context::set('test.store.id', null);
-        $this->assertSame(1, Context::store('test.store.id', 1));
+        $this->assertSame(1, Context::getOrSet('test.store.id', 1));
     }
 }

--- a/src/utils/tests/ContextTest.php
+++ b/src/utils/tests/ContextTest.php
@@ -31,4 +31,18 @@ class ContextTest extends TestCase
 
         $this->assertSame(2, Context::get('override.id'));
     }
+
+    public function testStore()
+    {
+        Context::set('test.store.id', null);
+        $this->assertSame(1, Context::store('test.store.id', function () {
+            return 1;
+        }));
+        $this->assertSame(1, Context::store('test.store.id', function () {
+            return 2;
+        }));
+
+        Context::set('test.store.id', null);
+        $this->assertSame(1, Context::store('test.store.id', 1));
+    }
 }

--- a/src/validation/src/Request/FormRequest.php
+++ b/src/validation/src/Request/FormRequest.php
@@ -105,7 +105,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function getValidatorInstance(): ValidatorInterface
     {
-        return Context::store($this->getContextValidatorKey(), function () {
+        return Context::getOrSet($this->getContextValidatorKey(), function () {
             $factory = $this->container->get(ValidationFactory::class);
 
             if (method_exists($this, 'validator')) {

--- a/src/validation/src/Request/FormRequest.php
+++ b/src/validation/src/Request/FormRequest.php
@@ -105,6 +105,11 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function getValidatorInstance(): ValidatorInterface
     {
+        $validatorKey = $this->getContextValidatorKey();
+        if (Context::has($validatorKey)) {
+            return Context::get($validatorKey);
+        }
+
         $factory = $this->container->get(ValidationFactory::class);
 
         if (method_exists($this, 'validator')) {
@@ -116,6 +121,8 @@ class FormRequest extends Request implements ValidatesWhenResolved
         if (method_exists($this, 'withValidator')) {
             $this->withValidator($validator);
         }
+
+        Context::set($validatorKey, $validator);
 
         return $validator;
     }
@@ -177,5 +184,17 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected function failedAuthorization()
     {
         throw new UnauthorizedException('This action is unauthorized.');
+    }
+
+    /**
+     *
+     * Get context validator key
+     *
+     * @return string
+     *
+     */
+    protected function getContextValidatorKey(): string
+    {
+        return sprintf('%s:%s',get_called_class(),ValidatorInterface::class);
     }
 }

--- a/src/validation/src/Request/FormRequest.php
+++ b/src/validation/src/Request/FormRequest.php
@@ -122,9 +122,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
             $this->withValidator($validator);
         }
 
-        Context::set($validatorKey, $validator);
-
-        return $validator;
+        return Context::set($validatorKey, $validator);
     }
 
     /**
@@ -187,14 +185,12 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
-     *
-     * Get context validator key
+     * Get context validator key.
      *
      * @return string
-     *
      */
     protected function getContextValidatorKey(): string
     {
-        return sprintf('%s:%s',get_called_class(),ValidatorInterface::class);
+        return sprintf('%s:%s', get_called_class(), ValidatorInterface::class);
     }
 }

--- a/src/validation/tests/Cases/Stub/DemoRequest.php
+++ b/src/validation/tests/Cases/Stub/DemoRequest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace HyperfTest\Validation\Cases\Stub;
 
+use Hyperf\Utils\Context;
 use Hyperf\Validation\Request\FormRequest;
 
 class DemoRequest extends FormRequest
@@ -37,5 +38,12 @@ class DemoRequest extends FormRequest
             'username' => 'required',
             'password' => 'required',
         ];
+    }
+
+    protected function withValidator($request)
+    {
+        Context::override('test.validation.DemoRequest.number', function ($id) {
+            return ++$id;
+        });
     }
 }

--- a/src/validation/tests/Cases/ValidationMiddlewareTest.php
+++ b/src/validation/tests/Cases/ValidationMiddlewareTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace HyperfTest\Validation\Cases;
 
 use Hyperf\Contract\NormalizerInterface;
+use Hyperf\Contract\ValidatorInterface;
 use Hyperf\Di\Container;
 use Hyperf\Di\MethodDefinitionCollector;
 use Hyperf\Di\MethodDefinitionCollectorInterface;
@@ -45,6 +46,13 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class ValidationMiddlewareTest extends TestCase
 {
+    protected function tearDown()
+    {
+        Mockery::close();
+        Context::set(DemoRequest::class . ':' . ValidatorInterface::class, null);
+        Context::set('test.validation.DemoRequest.number', 0);
+    }
+
     public function testProcess()
     {
         $container = $this->createContainer();
@@ -90,6 +98,19 @@ class ValidationMiddlewareTest extends TestCase
         $response = $middleware->process($request, $handler);
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('{"id":1,"request":{"username":"Hyperf","password":"Hyperf"}}', $response->getBody()->getContents());
+    }
+
+    public function testGetValidatorInstance()
+    {
+        $container = $this->createContainer();
+
+        $request = $container->get(DemoRequest::class);
+
+        $request->validated();
+        $this->assertSame(1, Context::get('test.validation.DemoRequest.number'));
+
+        $request->validated();
+        $this->assertSame(1, Context::get('test.validation.DemoRequest.number'));
     }
 
     public function createContainer()

--- a/src/validation/tests/Cases/ValidationMiddlewareTest.php
+++ b/src/validation/tests/Cases/ValidationMiddlewareTest.php
@@ -51,6 +51,7 @@ class ValidationMiddlewareTest extends TestCase
         Mockery::close();
         Context::set(DemoRequest::class . ':' . ValidatorInterface::class, null);
         Context::set('test.validation.DemoRequest.number', 0);
+        Context::set('http.request.parsedData', null);
     }
 
     public function testProcess()
@@ -103,7 +104,7 @@ class ValidationMiddlewareTest extends TestCase
     public function testGetValidatorInstance()
     {
         $container = $this->createContainer();
-
+        Context::set(ServerRequestInterface::class, new Request('POST', new Uri('/')));
         $request = $container->get(DemoRequest::class);
 
         $request->validated();


### PR DESCRIPTION
在 FormRequest getValidatorInstance 方法中，多次获取会多次去创建Validator
增加了协程上下文来存储 ValidatorInterface 对象

fix https://github.com/hyperf-cloud/hyperf/issues/693